### PR TITLE
fix general use of struct enum_val arrays

### DIFF
--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -173,6 +173,7 @@ struct enum_val xdp_modes[] = {
        {"native", XDP_MODE_NATIVE},
        {"skb", XDP_MODE_SKB},
        {"hw", XDP_MODE_HW},
+       {NULL, 0}
 };
 
 static struct prog_option load_options[] = {

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -34,6 +34,7 @@ struct enum_val xdp_modes[] = {
        {"native", XDP_MODE_NATIVE},
        {"skb", XDP_MODE_SKB},
        {"hw", XDP_MODE_HW},
+       {NULL, 0}
 };
 
 


### PR DESCRIPTION
These array need to be NULL terminated or else segfaults will happen.