### PR TITLE
APIs to get more program information, including xdp-loader using it

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -27,6 +27,8 @@ struct xdp_program *xdp_program__from_id(__u32 prog_id);
 void xdp_program__free(struct xdp_program *xdp_prog);
 
 const char *xdp_program__name(struct xdp_program *xdp_prog);
+const unsigned char *xdp_program__tag(struct xdp_program *xdp_prog);
+uint32_t xdp_program__id(struct xdp_program *xdp_prog);
 unsigned int xdp_program__run_prio(struct xdp_program *xdp_prog);
 void xdp_program__set_run_prio(struct xdp_program *xdp_prog, unsigned int run_prio);
 bool xdp_program__chain_call_enabled(struct xdp_program *xdp_prog,
@@ -47,3 +49,5 @@ int xdp_multiprog__attach(struct xdp_multiprog *mp,
                           int ifindex, bool force,
                           enum xdp_attach_mode mode);
 struct xdp_multiprog *xdp_multiprog__get_from_ifindex(int ifindex);
+struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
+					     struct xdp_multiprog *mp);

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -249,6 +249,22 @@ const char *xdp_program__name(struct xdp_program *prog)
 	return prog->prog_name;
 }
 
+const unsigned char *xdp_program__tag(struct xdp_program *prog)
+{
+	if (!prog)
+		return NULL;
+
+	return prog->prog_tag;
+}
+
+uint32_t xdp_program__id(struct xdp_program *xdp_prog)
+{
+	if (!xdp_prog)
+		return 0;
+
+	return xdp_prog->prog_id;
+}
+
 int xdp_program__print_chain_call_actions(struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len)
@@ -1515,6 +1531,17 @@ err:
 	return err;
 }
 
+struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
+					     struct xdp_multiprog *mp)
+{
+	if (!mp)
+		return NULL;
+
+	if (prog)
+		return prog->next;
+
+	return mp->first_prog;
+}
 
 /*int xdp_program__attach(const struct xdp_program *prog,
 			int ifindex, bool replace, enum xdp_attach_mode mode)


### PR DESCRIPTION
This adds API's to get the information needed to see what sub-programs are loaded for multi-programs.

The xdp-loader has been changed to show which programs are loaded on the interface.

These APIs are also needed for xdp-dump to figure out which programs to attach to.
