### PR TITLE
xdp-dump: fix multiple interfaces using the same XDP program

### DIFF
--- a/xdp-dump/xdpdump_bpf.c
+++ b/xdp-dump/xdpdump_bpf.c
@@ -47,6 +47,11 @@ struct bpf_map_def SEC("maps") xdpdump_perf_map = {
 };
 
 /*****************************************************************************
+ * .data section value storing the ifindex to capture
+ *****************************************************************************/
+__u32 capture_if_ifindex = 0xffffffff;
+
+/*****************************************************************************
  * trace_to_perf_buffer()
  *****************************************************************************/
 static inline void trace_to_perf_buffer(struct xdp_buff *xdp, bool fexit,
@@ -56,7 +61,7 @@ static inline void trace_to_perf_buffer(struct xdp_buff *xdp, bool fexit,
 	void *data = (void *)(long)xdp->data;
 	struct pkt_trace_metadata metadata;
 
-	if (data >= data_end)
+	if (data >= data_end || capture_if_ifindex != xdp->rxq->dev->ifindex)
 		return;
 
 	metadata.ifindex = xdp->rxq->dev->ifindex;


### PR DESCRIPTION
When multiple interfaces are using the same pinned XDP program we
should only capture packets from the interface requested. Without this
fix packets from all interfaces using this XDP program are captured.

To replicate the issues load a XDP program (pinning it), and assign it
to multiple interfaces. For example:

$ bpftool prog load test_bpf.o /sys/fs/bpf/eelcos_prog
$ bpftool net attach xdpgeneric pinned /sys/fs/bpf/eelcos_prog dev eth0
$ bpftool net attach xdpgeneric pinned /sys/fs/bpf/eelcos_prog dev eth1
$ xdpdump -i eth1

The last command will also show packets from eth0.