### PR TITLE
xdp-dump: double rlimit also for ENOTSUP errors

### DIFF
--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -492,9 +492,11 @@ rlimit_loop:
 	if (err) {
 		char err_msg[STRERR_BUFSIZE];
 
-		if (err == -EPERM) {
-			pr_debug("Permission denied when loading eBPF object; "
-				 "raising rlimit and retrying\n");
+		if (err == -EPERM || err == -ENOTSUP) {
+			pr_debug("%s when loading eBPF object; "
+				 "raising rlimit and retrying\n",
+				 err == -EPERM ? "Permission denied" :
+				 "Operation not supported");
 
 			if (!double_rlimit()) {
 				bpf_object__close(trace_obj);


### PR DESCRIPTION
When running some netns tests with xdpdump on the latest kernel I
noticed that sometimes loading fails with ENTOSUP due to a too low
rlimit. Fixed code to also try increasing the rlimit on this error.

Signed-off-by: Eelco Chaudron <echaudro@redhat.com>