### PR TITLE
Makefile: distclean submodule libbpf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,18 @@ help:
 config.mk:
 	sh configure
 
+clobber_submodules:
+	@if [ -d "lib/libbpf/src" ]; then \
+		rm -r lib/libbpf && mkdir lib/libbpf ;\
+		echo "removed submodule" ;\
+	fi
+
 clobber:
 	touch config.mk
 	$(MAKE) clean
 	rm -f config.mk cscope.*
 
-distclean: clobber
+distclean: clobber clobber_submodules
 
 clean:
 	@for i in $(SUBDIRS); \


### PR DESCRIPTION
It is possible to get stuck with an old git submodule commit id for libbpf, that is too old to e.g. compile against.

Offer a way out via having distclean remove the submodule directory.
As this will caused configure script to call git submodule update.
