### PR TITLE
xdp-dump: Explain why xdpdump is practial for debugging XDP

### DIFF
--- a/xdp-dump/README.org
+++ b/xdp-dump/README.org
@@ -13,6 +13,12 @@
 =xdpdump= is a simple XDP packet capture tool that tries to behave similar to
 =tcpdump=, however, it has no packet filter or decode capabilities.
 
+This can be used for debugging XDP programs that are already loaded on an
+interface.  Packets can be dumped/inspected before on *entry* to XDP program,
+or after at *exit* from an XDP program.  Further more, at *exit* the XDP
+action is also captured.  This means that even packets that are dropped at
+XDP-layer can be captured via this tool.
+
 =xdpdump= works by attaching a bpf trace program to the XDP entry and/or exit
 function which stores the raw packet in a perf trace buffer. If no XDP program
 is loaded this approach can not be used and the tool will use a libpcap


### PR DESCRIPTION
Make is more clear what makes xdpdump different from other utilities that can tcpdump via a perf ring-buffer.

I don't know how to export the man page version.