### PR TITLE
xdp-dump: add support for >16 XDP eBPF entry function names

### DIFF
--- a/xdp-dump/README.org
+++ b/xdp-dump/README.org
@@ -30,6 +30,7 @@ Options:
      --rx-capture <mode>    Capture point for the rx direction (valid values: entry,exit)
  -D, --list-interfaces      Print the list of available interfaces
  -i, --interface <ifname>   Name of interface to capture on
+ -p, --program-names <prog>  Specific program to attach to
  -s, --snapshot-length <snaplen>  Minimum bytes of packet to capture
  -w, --write <file>         Write raw packets to pcap file
  -x, --hex                  Print the full packet in hex
@@ -53,6 +54,13 @@ Display a list of available interfaces and any XDP program loaded
 ** -i, --interface <ifname>
 Listen on interface =ifname=. Note that if no XDP program is loaded on the
 interface it will use libpcap's live capture mode to capture the packets.
+** -p, --program-names <prog>
+The Linux API does not provide the full name of the attached eBPF entry function
+if it's longer than 15 characters. xdpdump will try to guess the correct
+function name from the available BTF debug information. However, if multiple
+functions exist with the same leading name, it can not pick the correct one. It
+will dump the available functions, and you can choose the correct one, and
+supply it with this option.
 ** -s, --snapshot-length <snaplen>
 Capture *snaplen* bytes of a packet rather than the default 262144 bytes.
 ** -w, --write <file>

--- a/xdp-dump/README.org
+++ b/xdp-dump/README.org
@@ -89,7 +89,8 @@ if_index  if_name           XDP program entry function
 Now we can try =xdpdump=:
 
 #+begin_src
-# xdpdump -i eth0
+# xdpdump -i eth0 -x
+listening on eth0, ingress XDP program xdpfilt_blk_all, capture mode entry, capture size 262144 bytes
 1584373839.460733895: packet size 102 bytes, captured 102 bytes on if_index 2, rx queue 0, @entry
   0x0000:  52 54 00 db 44 b6 52 54 00 34 38 da 08 00 45 48  RT..D.RT.48...EH
   0x0010:  00 58 d7 dd 40 00 40 06 ec c3 c0 a8 7a 01 c0 a8  .X..@.@.....z...
@@ -115,6 +116,7 @@ Below are two more examples redirecting the capture file to =tcpdump= or
 
 #+begin_src
 # xdpdump -i eth0 -w - | tcpdump -r - -n
+listening on eth0, ingress XDP program xdpfilt_blk_all, capture mode entry, capture size 262144 bytes
 reading from file -, link-type EN10MB (Ethernet)
 15:55:09.075887 IP 192.168.122.1.40928 > 192.168.122.100.ssh: Flags [P.], seq 3857553815:3857553851, ack 3306438882, win 501, options [nop,nop,TS val 1997449167 ecr 1075234328], length 36
 15:55:09.077756 IP 192.168.122.1.40928 > 192.168.122.100.ssh: Flags [.], ack 37, win 501, options [nop,nop,TS val 1997449169 ecr 1075244363], length 0
@@ -123,6 +125,7 @@ reading from file -, link-type EN10MB (Ethernet)
 
 #+begin_src
 # xdpdump -i eth0 -w - | tshark -r - -n
+listening on eth0, ingress XDP program xdpfilt_blk_all, capture mode entry, capture size 262144 bytes
     1   0.000000 192.168.122.1 → 192.168.122.100 SSH 102 Client: Encrypted packet (len=36)
     2   0.000646 192.168.122.1 → 192.168.122.100 TCP 66 40158 → 22 [ACK] Seq=37 Ack=37 Win=1467 Len=0 TSval=1997621571 TSecr=1075416765
     3  12.218164 192.168.122.1 → 192.168.122.100 SSH 102 Client: Encrypted packet (len=36)

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -130,6 +130,22 @@ static const char *get_xdp_action_string(enum xdp_action act)
 }
 
 /*****************************************************************************
+ * get_capture_mode_string()
+ *****************************************************************************/
+static const char *get_capture_mode_string(unsigned int mode)
+{
+	switch(mode) {
+	case RX_FLAG_FENTRY:
+		return "entry";
+	case RX_FLAG_FEXIT:
+		return "exit";
+	case RX_FLAG_FENTRY | RX_FLAG_FEXIT:
+		return "entry/exit";
+	}
+	return "unknown";
+}
+
+/*****************************************************************************
  * snprinth()
  *****************************************************************************/
 #define SNPRINTH_MIN_BUFFER_SIZE sizeof("0xffff:  00 11 22 33 44 55 66 77 88" \
@@ -330,6 +346,13 @@ static bool capture_on_legacy_interface(struct dumpopt *cfg)
 			goto error_exit;
 		}
 	}
+
+	/* No more error conditions, display some capture information */
+	fprintf(stderr, "listening on %s, link-type %s (%s), "
+		"capture size %d bytes\n", cfg->iface.ifname,
+		pcap_datalink_val_to_name(pcap_datalink(pcap)),
+		pcap_datalink_val_to_description(pcap_datalink(pcap)),
+		cfg->snaplen);
 
 	/* Loop for receive packets on live interface. */
 	exit_pcap = pcap;
@@ -647,6 +670,12 @@ rlimit_loop:
 			goto error_exit;
 		}
 	}
+
+	/* No more error conditions, display some capture information */
+	fprintf(stderr, "listening on %s, ingress XDP program %s, "
+		"capture mode %s, capture size %d bytes\n",
+		cfg->iface.ifname, prog_name,
+		get_capture_mode_string(cfg->rx_capture), cfg->snaplen);
 
 	/* Setup perf context */
 	memset(&perf_ctx, 0, sizeof(perf_ctx));


### PR DESCRIPTION
The Linux API does not provide the full name of the attached eBPF
entry function if it's longer than 15 characters. xdpdump will try to
guess the correct function name from the available BTF debug
information. However, if multiple functions exist with the same
leading name, it can not pick the correct one. It will dump the
available functions, and you can choose the correct one, and supply it
with the -m option. For example:

$ xdpdump -i eth0
ERROR: Can't identify the full XDP main function!
The following is a list of candidates:
  xdp_test_prog_with_a_long_name
  xdp_test_prog_with_a_long_name_too
  xdp_test_prog_w
Please use the -m option to pick the correct one.

$ ./xdpdump -i eth0 -m xdp_test_prog_with_a_long_name
1588252724.025055871: @entry: packet size 102 bytes on if_index 2, rx queue 0
1588252724.026463296: @entry: packet size 66 bytes on if_index 2, rx queue 0
1588252724.026786186: @entry: packet size 66 bytes on if_index 2, rx queue 0