### PR TITLE
Rework libxdp API and use it in all utilities

### DIFF
--- a/configure
+++ b/configure
@@ -121,9 +121,11 @@ check_libbpf()
 int main(int argc, char **argv) {
 	void *ptr;
 	DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts, .pin_root_path = "/path");
+	DECLARE_LIBBPF_OPTS(bpf_xdp_set_link_opts, lopts, .old_fd = -1);
 	(void) bpf_object__open_file("file", &opts);
 	(void) bpf_program__name(ptr);
 	(void) bpf_map__set_initial_value(ptr, ptr, 0);
+	(void) bpf_set_link_xdp_fd_opts(0, 0, 0, &lopts);
 	return 0;
 }
 EOF

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -73,7 +73,6 @@ struct xdp_program *xdp_multiprog__next_prog(const struct xdp_program *prog,
 void xdp_multiprog__close(struct xdp_multiprog *mp);
 int xdp_multiprog__detach(struct xdp_multiprog *mp, int ifindex);
 enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp);
-uint32_t xdp_multiprog__dispatcher_id(const struct xdp_multiprog *mp);
-const unsigned char *xdp_multiprog__dispatcher_tag(const struct xdp_multiprog *mp);
+struct xdp_program *xdp_multiprog__dispatcher(const struct xdp_multiprog *mp);
 
 #endif

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -42,17 +42,17 @@ struct xdp_program *xdp_program__from_id(__u32 prog_id);
 
 void xdp_program__close(struct xdp_program *xdp_prog);
 
-const char *xdp_program__name(struct xdp_program *xdp_prog);
-const unsigned char *xdp_program__tag(struct xdp_program *xdp_prog);
+const char *xdp_program__name(const struct xdp_program *xdp_prog);
+const unsigned char *xdp_program__tag(const struct xdp_program *xdp_prog);
 struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
-uint32_t xdp_program__id(struct xdp_program *xdp_prog);
-unsigned int xdp_program__run_prio(struct xdp_program *xdp_prog);
+uint32_t xdp_program__id(const struct xdp_program *xdp_prog);
+unsigned int xdp_program__run_prio(const struct xdp_program *xdp_prog);
 void xdp_program__set_run_prio(struct xdp_program *xdp_prog, unsigned int run_prio);
-bool xdp_program__chain_call_enabled(struct xdp_program *xdp_prog,
+bool xdp_program__chain_call_enabled(const struct xdp_program *xdp_prog,
 				     enum xdp_action action);
 void xdp_program__set_chain_call_enabled(struct xdp_program *prog, unsigned int action,
                                          bool enabled);
-int xdp_program__print_chain_call_actions(struct xdp_program *prog,
+int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len);
 int xdp_program__attach(struct xdp_program *xdp_prog,
@@ -65,10 +65,12 @@ int xdp_program__detach_multi(struct xdp_program **progs, size_t num_progs,
                               int ifindex, enum xdp_attach_mode mode);
 
 struct xdp_multiprog *xdp_multiprog__get_from_ifindex(int ifindex);
-struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
-					     struct xdp_multiprog *mp);
+struct xdp_program *xdp_multiprog__next_prog(const struct xdp_program *prog,
+					     const struct xdp_multiprog *mp);
 void xdp_multiprog__close(struct xdp_multiprog *mp);
 int xdp_multiprog__detach(struct xdp_multiprog *mp, int ifindex);
-enum xdp_attach_mode xdp_multiprog__attach_mode(struct xdp_multiprog *mp);
+enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp);
+uint32_t xdp_multiprog__dispatcher_id(const struct xdp_multiprog *mp);
+const unsigned char *xdp_multiprog__dispatcher_tag(const struct xdp_multiprog *mp);
 
 #endif

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -6,18 +6,34 @@
  * Copyright (C) 2020 Toke Høiland-Jørgensen <toke@redhat.com>
  */
 
+#ifndef __LIBXDP_LIBXDP_H
+#define __LIBXDP_LIBXDP_H
+
 #include <linux/bpf.h>
 #include <bpf/bpf.h>
 #include "xdp_helpers.h"
-#include "util.h"
 
 #define XDP_BPFFS_ENVVAR "LIBXDP_BPFFS"
+
+enum xdp_attach_mode {
+                      XDP_MODE_UNSPEC = 0,
+                      XDP_MODE_NATIVE,
+                      XDP_MODE_SKB,
+                      XDP_MODE_HW
+};
 
 struct xdp_program;
 struct xdp_multiprog;
 
+long libxdp_get_error(const void *ptr);
+int libxdp_strerror(int err, char *buf, size_t size);
+
+
 struct xdp_program *xdp_program__from_bpf_obj(struct bpf_object *obj,
 					      const char *prog_name);
+struct xdp_program *xdp_program__find_file(const char *filename,
+					   const char *prog_name,
+					   struct bpf_object_open_opts *opts);
 struct xdp_program *xdp_program__open_file(const char *filename,
 					   const char *prog_name,
 					   struct bpf_object_open_opts *opts);
@@ -51,3 +67,5 @@ int xdp_multiprog__attach(struct xdp_multiprog *mp,
 struct xdp_multiprog *xdp_multiprog__get_from_ifindex(int ifindex);
 struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
 					     struct xdp_multiprog *mp);
+
+#endif

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -44,6 +44,7 @@ void xdp_program__close(struct xdp_program *xdp_prog);
 
 const char *xdp_program__name(struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(struct xdp_program *xdp_prog);
+struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
 uint32_t xdp_program__id(struct xdp_program *xdp_prog);
 unsigned int xdp_program__run_prio(struct xdp_program *xdp_prog);
 void xdp_program__set_run_prio(struct xdp_program *xdp_prog, unsigned int run_prio);
@@ -51,21 +52,23 @@ bool xdp_program__chain_call_enabled(struct xdp_program *xdp_prog,
 				     enum xdp_action action);
 void xdp_program__set_chain_call_enabled(struct xdp_program *prog, unsigned int action,
                                          bool enabled);
-
 int xdp_program__print_chain_call_actions(struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len);
+int xdp_program__attach(struct xdp_program *xdp_prog,
+                        int ifindex, enum xdp_attach_mode mode);
+int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,
+                              int ifindex, enum xdp_attach_mode mode);
+int xdp_program__detach(struct xdp_program *xdp_prog,
+                        int ifindex, enum xdp_attach_mode mode);
+int xdp_program__detach_multi(struct xdp_program **progs, size_t num_progs,
+                              int ifindex, enum xdp_attach_mode mode);
 
-struct xdp_multiprog *xdp_multiprog__generate(struct xdp_program **progs,
-                                              size_t num_progs);
-void xdp_multiprog__close(struct xdp_multiprog *mp);
-int xdp_multiprog__pin(struct xdp_multiprog *mp);
-int xdp_multiprog__unpin(struct xdp_multiprog *mp);
-int xdp_multiprog__attach(struct xdp_multiprog *mp,
-                          int ifindex, bool force,
-                          enum xdp_attach_mode mode);
 struct xdp_multiprog *xdp_multiprog__get_from_ifindex(int ifindex);
 struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
 					     struct xdp_multiprog *mp);
+void xdp_multiprog__close(struct xdp_multiprog *mp);
+int xdp_multiprog__detach(struct xdp_multiprog *mp, int ifindex);
+enum xdp_attach_mode xdp_multiprog__attach_mode(struct xdp_multiprog *mp);
 
 #endif

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -24,7 +24,7 @@ struct xdp_program *xdp_program__open_file(const char *filename,
 struct xdp_program *xdp_program__from_fd(int fd);
 struct xdp_program *xdp_program__from_id(__u32 prog_id);
 
-void xdp_program__free(struct xdp_program *xdp_prog);
+void xdp_program__close(struct xdp_program *xdp_prog);
 
 const char *xdp_program__name(struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(struct xdp_program *xdp_prog);
@@ -42,7 +42,7 @@ int xdp_program__print_chain_call_actions(struct xdp_program *prog,
 
 struct xdp_multiprog *xdp_multiprog__generate(struct xdp_program **progs,
                                               size_t num_progs);
-void xdp_multiprog__free(struct xdp_multiprog *mp);
+void xdp_multiprog__close(struct xdp_multiprog *mp);
 int xdp_multiprog__pin(struct xdp_multiprog *mp);
 int xdp_multiprog__unpin(struct xdp_multiprog *mp);
 int xdp_multiprog__attach(struct xdp_multiprog *mp,

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -74,6 +74,7 @@ struct xdp_program *xdp_multiprog__next_prog(const struct xdp_program *prog,
 void xdp_multiprog__close(struct xdp_multiprog *mp);
 int xdp_multiprog__detach(struct xdp_multiprog *mp, int ifindex);
 enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp);
-struct xdp_program *xdp_multiprog__dispatcher(const struct xdp_multiprog *mp);
+struct xdp_program *xdp_multiprog__main_prog(const struct xdp_multiprog *mp);
+bool xdp_multiprog__is_legacy(const struct xdp_multiprog *mp);
 
 #endif

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -48,6 +48,7 @@ const char *xdp_program__name(const struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(const struct xdp_program *xdp_prog);
 struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
 uint32_t xdp_program__id(const struct xdp_program *xdp_prog);
+int xdp_program__fd(const struct xdp_program *xdp_prog);
 unsigned int xdp_program__run_prio(const struct xdp_program *xdp_prog);
 void xdp_program__set_run_prio(struct xdp_program *xdp_prog, unsigned int run_prio);
 bool xdp_program__chain_call_enabled(const struct xdp_program *xdp_prog,

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -39,9 +39,11 @@ struct xdp_program *xdp_program__open_file(const char *filename,
 					   struct bpf_object_open_opts *opts);
 struct xdp_program *xdp_program__from_fd(int fd);
 struct xdp_program *xdp_program__from_id(__u32 prog_id);
+struct xdp_program *xdp_program__from_pin(const char *pin_path);
 
 void xdp_program__close(struct xdp_program *xdp_prog);
 
+bool xdp_program__is_attached(const struct xdp_program *xdp_prog, int ifindex);
 const char *xdp_program__name(const struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(const struct xdp_program *xdp_prog);
 struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
@@ -55,6 +57,7 @@ void xdp_program__set_chain_call_enabled(struct xdp_program *prog, unsigned int 
 int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len);
+int xdp_program__pin(struct xdp_program *xdp_prog, const char *pin_path);
 int xdp_program__attach(struct xdp_program *xdp_prog,
                         int ifindex, enum xdp_attach_mode mode);
 int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -48,15 +48,17 @@ bool xdp_program__is_attached(const struct xdp_program *xdp_prog, int ifindex);
 const char *xdp_program__name(const struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(const struct xdp_program *xdp_prog);
 struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
-struct btf *xdp_program__btf(struct xdp_program *xdp_prog);
+const struct btf *xdp_program__btf(struct xdp_program *xdp_prog);
 uint32_t xdp_program__id(const struct xdp_program *xdp_prog);
 int xdp_program__fd(const struct xdp_program *xdp_prog);
 unsigned int xdp_program__run_prio(const struct xdp_program *xdp_prog);
-void xdp_program__set_run_prio(struct xdp_program *xdp_prog, unsigned int run_prio);
+int xdp_program__set_run_prio(struct xdp_program *xdp_prog,
+                              unsigned int run_prio);
 bool xdp_program__chain_call_enabled(const struct xdp_program *xdp_prog,
 				     enum xdp_action action);
-void xdp_program__set_chain_call_enabled(struct xdp_program *prog, unsigned int action,
-                                         bool enabled);
+int xdp_program__set_chain_call_enabled(struct xdp_program *prog,
+                                        unsigned int action,
+                                        bool enabled);
 int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len);

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -47,6 +47,7 @@ bool xdp_program__is_attached(const struct xdp_program *xdp_prog, int ifindex);
 const char *xdp_program__name(const struct xdp_program *xdp_prog);
 const unsigned char *xdp_program__tag(const struct xdp_program *xdp_prog);
 struct bpf_object *xdp_program__bpf_obj(struct xdp_program *xdp_prog);
+struct btf *xdp_program__btf(struct xdp_program *xdp_prog);
 uint32_t xdp_program__id(const struct xdp_program *xdp_prog);
 int xdp_program__fd(const struct xdp_program *xdp_prog);
 unsigned int xdp_program__run_prio(const struct xdp_program *xdp_prog);

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -14,6 +14,7 @@
 #include "xdp_helpers.h"
 
 #define XDP_BPFFS_ENVVAR "LIBXDP_BPFFS"
+#define XDP_OBJECT_ENVVAR "LIBXDP_OBJECT_PATH"
 
 enum xdp_attach_mode {
                       XDP_MODE_UNSPEC = 0,

--- a/headers/xdp/prog_dispatcher.h
+++ b/headers/xdp/prog_dispatcher.h
@@ -15,6 +15,7 @@
 struct xdp_dispatcher_config {
 	__u8 num_progs_enabled;
 	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
+	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
 };
 
 #endif

--- a/headers/xdp/prog_dispatcher.h
+++ b/headers/xdp/prog_dispatcher.h
@@ -7,6 +7,12 @@
 
 #define XDP_METADATA_SECTION "xdp_metadata"
 #define XDP_DISPATCHER_VERSION 1
+/* default retval for dispatcher corresponds to the highest bit in the
+ * chain_call_actions bitmap; we use this to make sure the dispatcher always
+ * continues the calls chain if a function does not have an freplace program
+ * attached.
+ */
+#define XDP_DISPATCHER_RETVAL 31
 
 #ifndef MAX_DISPATCHER_ACTIONS
 #define MAX_DISPATCHER_ACTIONS 10

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -33,10 +33,10 @@ EXTRA_USER_DEPS +=
 
 LDFLAGS+=-L$(LIBXDP_DIR)
 ifeq ($(DYNAMIC_LIBXDP),1)
-	LDLIBS+=-lxdp
+	LDLIBS:=-lxdp $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.so.$(LIBXDP_VERSION)
 else
-	LDLIBS+=-l:libxdp.a
+	LDLIBS:=-l:libxdp.a $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.a
 endif
 

--- a/lib/defines.mk
+++ b/lib/defines.mk
@@ -1,4 +1,4 @@
-CFLAGS ?= -O2 -g -Werror
+CFLAGS ?= -O2 -g
 BPF_CFLAGS ?= -Wno-visibility
 
 include $(LIB_DIR)/../config.mk
@@ -22,7 +22,7 @@ ifneq ($(PRODUCTION),1)
 DEFINES += -DDEBUG
 endif
 
-CFLAGS += $(DEFINES)
+CFLAGS += -Werror $(DEFINES)
 BPF_CFLAGS += $(DEFINES)
 
 CONFIGMK := $(LIB_DIR)/../config.mk

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1829,18 +1829,10 @@ enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp)
 	return mp->attach_mode;
 }
 
-uint32_t xdp_multiprog__dispatcher_id(const struct xdp_multiprog *mp)
+struct xdp_program *xdp_multiprog__dispatcher(const struct xdp_multiprog *mp)
 {
 	if (!mp)
-		return 0;
+		return NULL;
 
-	return xdp_program__id(mp->dispatcher);
-}
-
-const unsigned char *xdp_multiprog__dispatcher_tag(const struct xdp_multiprog *mp)
-{
-	if (!mp)
-		return 0;
-
-	return xdp_program__tag(mp->dispatcher);
+	return mp->dispatcher;
 }

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -520,7 +520,7 @@ static struct xdp_program *xdp_program__new()
 	return xdp_prog;
 }
 
-void xdp_program__free(struct xdp_program *xdp_prog)
+void xdp_program__close(struct xdp_program *xdp_prog)
 {
 	if (!xdp_prog)
 		return;
@@ -595,7 +595,7 @@ struct xdp_program *xdp_program__from_bpf_obj(struct bpf_object *obj,
 
 	return xdp_prog;
 err:
-	xdp_program__free(xdp_prog);
+	xdp_program__close(xdp_prog);
 	return ERR_PTR(err);
 }
 
@@ -627,7 +627,7 @@ struct xdp_program *xdp_program__open_file(const char *filename,
 
 	return xdp_prog;
 err:
-	xdp_program__free(xdp_prog);
+	xdp_program__close(xdp_prog);
 	bpf_object__close(obj);
 	return ERR_PTR(err);
 }
@@ -812,17 +812,17 @@ static struct xdp_program *xdp_program__clone(struct xdp_program *prog)
 }
 
 
-void xdp_multiprog__free(struct xdp_multiprog *mp)
+void xdp_multiprog__close(struct xdp_multiprog *mp)
 {
 	struct xdp_program *p, *next = NULL;
 
 	if (!mp)
 		return;
 
-	xdp_program__free(mp->dispatcher);
+	xdp_program__close(mp->dispatcher);
 	for (p = mp->first_prog; p; p = next) {
 		next = p->next;
-		xdp_program__free(p);
+		xdp_program__close(p);
 	}
 }
 
@@ -977,7 +977,7 @@ err:
 	prog = mp->first_prog;
 	while (prog) {
 		p = prog->next;
-		xdp_program__free(prog);
+		xdp_program__close(prog);
 		prog = p;
 	}
 	mp->first_prog = NULL;
@@ -1079,7 +1079,7 @@ out:
 	return err;
 
 err:
-	xdp_program__free(prog);
+	xdp_program__close(prog);
 	goto out;
 }
 
@@ -1225,7 +1225,7 @@ static int xdp_multiprog__link_prog(struct xdp_multiprog *mp,
 	return 0;
 
 err_free:
-	xdp_program__free(new_prog);
+	xdp_program__close(new_prog);
 err:
 	return err;
 }
@@ -1300,7 +1300,7 @@ struct xdp_multiprog *xdp_multiprog__generate(struct xdp_program **progs,
 	return mp;
 
 err:
-	xdp_multiprog__free(mp);
+	xdp_multiprog__close(mp);
 	return ERR_PTR(err);
 }
 

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -336,6 +336,14 @@ uint32_t xdp_program__id(const struct xdp_program *xdp_prog)
 	return xdp_prog->prog_id;
 }
 
+int xdp_program__fd(const struct xdp_program *xdp_prog)
+{
+	if (!xdp_prog)
+		return -1;
+
+	return xdp_prog->prog_fd;
+}
+
 int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len)

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1863,7 +1863,7 @@ static int xdp_multiprog__attach(struct xdp_multiprog *old_mp,
 		xdp_flags |= XDP_FLAGS_DRV_MODE;
 		break;
 	case XDP_MODE_HW:
-		return -EOPNOTSUPP;
+		xdp_flags |= XDP_FLAGS_HW_MODE;
 		break;
 	case XDP_MODE_UNSPEC:
 		break;
@@ -1880,7 +1880,7 @@ static int xdp_multiprog__attach(struct xdp_multiprog *old_mp,
 			pr_debug("XDP already loaded on device\n");
 			break;
 		case EOPNOTSUPP:
-			pr_debug("Native XDP not supported; try using SKB mode\n");
+			pr_debug("XDP mode not supported; try using SKB mode\n");
 			break;
 		default:
 			break;

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -941,7 +941,8 @@ struct xdp_program *xdp_program__from_pin(const char *pin_path)
 	fd = bpf_obj_get(pin_path);
 	if (fd < 0) {
 		err = -errno;
-		pr_warn("couldn't get program fd: %s", strerror(-err));
+		pr_warn("couldn't get program fd from %s: %s",
+			pin_path, strerror(-err));
 		return ERR_PTR(err);
 	}
 

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -694,6 +694,8 @@ void xdp_program__close(struct xdp_program *xdp_prog)
 		else if (xdp_prog->btf)
 			btf__free(xdp_prog->btf);
 	}
+
+	free(xdp_prog);
 }
 
 static int xdp_program__fill_from_obj(struct xdp_program *xdp_prog,
@@ -1182,6 +1184,8 @@ void xdp_multiprog__close(struct xdp_multiprog *mp)
 		next = p->next;
 		xdp_program__close(p);
 	}
+
+	free(mp);
 }
 
 static int xdp_multiprog__main_fd(struct xdp_multiprog *mp)

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -643,6 +643,12 @@ static int xdp_program__fill_from_obj(struct xdp_program *xdp_prog,
 	if (!xdp_prog->prog_name)
 		return -ENOMEM;
 
+	if (strlen(xdp_prog->prog_name) > BPF_OBJ_NAME_LEN - 1) {
+		pr_warn("Please keep XDP function names shorter than %d characters\n",
+			BPF_OBJ_NAME_LEN);
+		return -EINVAL;
+	}
+
 	xdp_prog->bpf_prog = bpf_prog;
 	xdp_prog->bpf_obj = obj;
 	xdp_prog->btf = bpf_object__btf(obj);

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -92,7 +92,7 @@ int libxdp_strerror(int err, char *buf, size_t size)
 	return libbpf_strerror(err, buf, size);
 }
 
-static int check_snprintf(char *buf, size_t buf_len, const char *format, ...)
+static int try_snprintf(char *buf, size_t buf_len, const char *format, ...)
 {
 	va_list args;
 	int len;
@@ -173,7 +173,7 @@ static const char *get_bpffs_dir()
 		goto err;
 	}
 
-	err = check_snprintf(bpffs_dir, sizeof(bpffs_dir), "%s/xdp", parent);
+	err = try_snprintf(bpffs_dir, sizeof(bpffs_dir), "%s/xdp", parent);
 	if (err)
 		goto err;
 
@@ -611,8 +611,8 @@ static int xdp_program__parse_btf(struct xdp_program *xdp_prog)
 		}
 	}
 
-	err = check_snprintf(struct_name, sizeof(struct_name), "_%s",
-			     xdp_program__name(xdp_prog));
+	err = try_snprintf(struct_name, sizeof(struct_name), "_%s",
+			   xdp_program__name(xdp_prog));
 	if (err)
 		return err;
 
@@ -805,7 +805,7 @@ static int find_bpf_file(char *buf, size_t buf_size, const char *progname)
 	int err;
 
 	for (path = bpf_obj_paths; *path; path++) {
-		err = check_snprintf(buf, buf_size, "%s/%s", *path, progname);
+		err = try_snprintf(buf, buf_size, "%s/%s", *path, progname);
 		if (err)
 			return err;
 
@@ -1253,8 +1253,8 @@ static int xdp_multiprog__link_pinned_progs(struct xdp_multiprog *mp)
 	if (IS_ERR(bpffs_dir))
 		return PTR_ERR(bpffs_dir);
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
-			     bpffs_dir, mp->main_prog->prog_id);
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
+			   bpffs_dir, mp->main_prog->prog_id);
 	if (err)
 		return err;
 
@@ -1273,8 +1273,8 @@ static int xdp_multiprog__link_pinned_progs(struct xdp_multiprog *mp)
 
 	for (i = 0; i < mp->config.num_progs_enabled; i++) {
 
-		err = check_snprintf(buf, sizeof(buf), "%s/prog%d-prog",
-				     pin_path, i);
+		err = try_snprintf(buf, sizeof(buf), "%s/prog%d-prog",
+				   pin_path, i);
 		if (err)
 			goto err;
 
@@ -1293,7 +1293,7 @@ static int xdp_multiprog__link_pinned_progs(struct xdp_multiprog *mp)
 				prog_fd, strerror(-err));
 			goto err;
 		}
-		err = check_snprintf(buf, sizeof(buf), "prog%d", i);
+		err = try_snprintf(buf, sizeof(buf), "prog%d", i);
 		if (err)
 			goto err;
 		prog->attach_name = strdup(buf);
@@ -1515,7 +1515,7 @@ static int xdp_multiprog__link_prog(struct xdp_multiprog *mp,
 	pr_debug("Linking prog %s as multiprog entry %zu\n",
 		 xdp_program__name(prog), mp->num_links);
 
-	err = check_snprintf(buf, sizeof(buf), "prog%d", mp->num_links);
+	err = try_snprintf(buf, sizeof(buf), "prog%d", mp->num_links);
 	if (err)
 		goto err;
 
@@ -1676,8 +1676,8 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 	if (IS_ERR(bpffs_dir))
 		return PTR_ERR(bpffs_dir);
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
-			     bpffs_dir, mp->main_prog->prog_id);
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
+			   bpffs_dir, mp->main_prog->prog_id);
 	if (err)
 		return err;
 
@@ -1701,8 +1701,8 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 			goto err_unpin;
 		}
 
-		err = check_snprintf(buf, sizeof(buf), "%s/%s-link",
-				     pin_path, prog->attach_name);
+		err = try_snprintf(buf, sizeof(buf), "%s/%s-link",
+				   pin_path, prog->attach_name);
 		if (err)
 			goto err_unpin;
 
@@ -1714,8 +1714,8 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 		pr_debug("Pinned link for prog %s at %s\n",
 			 xdp_program__name(prog), buf);
 
-		err = check_snprintf(buf, sizeof(buf), "%s/%s-prog",
-				     pin_path, prog->attach_name);
+		err = try_snprintf(buf, sizeof(buf), "%s/%s-prog",
+				   pin_path, prog->attach_name);
 		if (err)
 			goto err_unpin;
 
@@ -1733,11 +1733,11 @@ out:
 
 err_unpin:
 	for (prog = mp->first_prog; prog; prog = prog->next) {
-		if (!check_snprintf(buf, sizeof(buf), "%s/%s-link",
-				    pin_path, prog->attach_name))
+		if (!try_snprintf(buf, sizeof(buf), "%s/%s-link",
+				  pin_path, prog->attach_name))
 			unlink(buf);
-		if (!check_snprintf(buf, sizeof(buf), "%s/%s-prog",
-				    pin_path, prog->attach_name))
+		if (!try_snprintf(buf, sizeof(buf), "%s/%s-prog",
+				  pin_path, prog->attach_name))
 			unlink(buf);
 	}
 	rmdir(pin_path);
@@ -1758,8 +1758,8 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 	if (IS_ERR(bpffs_dir))
 		return PTR_ERR(bpffs_dir);
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
-			     bpffs_dir, mp->main_prog->prog_id);
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d",
+			   bpffs_dir, mp->main_prog->prog_id);
 	if (err)
 		return err;
 
@@ -1771,8 +1771,8 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 		 mp->main_prog->prog_fd, pin_path);
 
 	for (prog = mp->first_prog; prog; prog = prog->next) {
-		err = check_snprintf(buf, sizeof(buf), "%s/%s-link",
-				     pin_path, prog->attach_name);
+		err = try_snprintf(buf, sizeof(buf), "%s/%s-link",
+				   pin_path, prog->attach_name);
 		if (err)
 			goto out;
 
@@ -1786,8 +1786,8 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 		pr_debug("Unpinned link for prog %s from %s\n",
 			 xdp_program__name(prog), buf);
 
-		err = check_snprintf(buf, sizeof(buf), "%s/%s-prog",
-				     pin_path, prog->attach_name);
+		err = try_snprintf(buf, sizeof(buf), "%s/%s-prog",
+				   pin_path, prog->attach_name);
 		if (err)
 			goto out;
 

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1280,6 +1280,7 @@ static int xdp_multiprog__fill_from_fd(struct xdp_multiprog *mp, int prog_fd)
 	if (err)
 		goto err;
 
+	mp->is_loaded = true;
 	pr_debug("Found multiprog with id %d and %zu component progs\n",
 		 mp->dispatcher->prog_id, mp->num_links);
 

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1082,6 +1082,8 @@ int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,
 
 	err = xdp_multiprog__attach(NULL, mp, ifindex, mode);
 	if (err) {
+		pr_warn("Failed to attach dispatcher on ifindex %d: %s\n",
+			ifindex, strerror(-err));
 		xdp_multiprog__unpin(mp);
 		goto out_close;
 	}
@@ -1435,7 +1437,8 @@ legacy:
 	}
 
 	mp->is_loaded = true;
-	pr_debug("Found multiprog with id %d and %zu component progs\n",
+	pr_debug("Found %s with id %d and %zu component progs\n",
+		 mp->is_legacy ? "legacy program" : "multiprog",
 		 mp->main_prog->prog_id, mp->num_links);
 
 out:

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -247,7 +247,7 @@ bool xdp_program__is_attached(const struct xdp_program *xdp_prog, int ifindex)
 	struct xdp_multiprog *mp;
 	bool ret = false;
 
-	if (!xdp_prog->prog_id)
+	if (!xdp_prog || !xdp_prog->prog_id)
 		return false;
 
 	mp = xdp_multiprog__get_from_ifindex(ifindex);
@@ -997,7 +997,7 @@ static int cmp_xdp_programs(const void *_a, const void *_b)
 
 int xdp_program__pin(struct xdp_program *prog, const char *pin_path)
 {
-	if (!prog->prog_fd)
+	if (!prog || !prog->prog_fd)
 		return -EINVAL;
 
 	return bpf_program__pin(prog->bpf_prog, pin_path);
@@ -1055,6 +1055,9 @@ int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,
 {
 	struct xdp_multiprog *old_mp, *mp;
 	int err = 0;
+
+	if (!progs || !num_progs)
+		return -EINVAL;
 
 	old_mp = xdp_multiprog__get_from_ifindex(ifindex);
 	if (!IS_ERR_OR_NULL(old_mp)) {
@@ -1678,7 +1681,7 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 	const char *bpffs_dir;
 	int err = 0, lock_fd;
 
-	if (!mp)
+	if (!mp || mp->is_legacy)
 		return -EINVAL;
 
 	bpffs_dir = get_bpffs_dir();
@@ -1760,7 +1763,7 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 	const char *bpffs_dir;
 	int err = 0, lock_fd;
 
-	if (!mp)
+	if (!mp || mp->is_legacy)
 		return -EINVAL;
 
 	bpffs_dir = get_bpffs_dir();

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -233,7 +233,7 @@ static int xdp_lock_release(int lock_fd)
 	return err;
 }
 
-static struct btf *xdp_program__btf(struct xdp_program *xdp_prog)
+struct btf *xdp_program__btf(struct xdp_program *xdp_prog)
 {
 	if (!xdp_prog)
 		return NULL;

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -253,7 +253,7 @@ void xdp_program__set_chain_call_enabled(struct xdp_program *prog,
 		prog->chain_call_actions &= ~(1<<action);
 }
 
-bool xdp_program__chain_call_enabled(struct xdp_program *prog,
+bool xdp_program__chain_call_enabled(const struct xdp_program *prog,
 				     enum xdp_action action)
 {
 	if (!prog)
@@ -262,7 +262,7 @@ bool xdp_program__chain_call_enabled(struct xdp_program *prog,
 	return !!(prog->chain_call_actions & (1<<action));
 }
 
-unsigned int xdp_program__run_prio(struct xdp_program *prog)
+unsigned int xdp_program__run_prio(const struct xdp_program *prog)
 {
 	if (!prog)
 		return XDP_DEFAULT_RUN_PRIO;
@@ -279,7 +279,7 @@ void xdp_program__set_run_prio(struct xdp_program *prog, unsigned int run_prio)
 	prog->run_prio = run_prio;
 }
 
-const char *xdp_program__name(struct xdp_program *prog)
+const char *xdp_program__name(const struct xdp_program *prog)
 {
 	if (!prog)
 		return NULL;
@@ -296,7 +296,7 @@ struct bpf_object *xdp_program__bpf_obj(struct xdp_program *prog)
 }
 
 
-const unsigned char *xdp_program__tag(struct xdp_program *prog)
+const unsigned char *xdp_program__tag(const struct xdp_program *prog)
 {
 	if (!prog)
 		return NULL;
@@ -304,7 +304,7 @@ const unsigned char *xdp_program__tag(struct xdp_program *prog)
 	return prog->prog_tag;
 }
 
-uint32_t xdp_program__id(struct xdp_program *xdp_prog)
+uint32_t xdp_program__id(const struct xdp_program *xdp_prog)
 {
 	if (!xdp_prog)
 		return 0;
@@ -312,7 +312,7 @@ uint32_t xdp_program__id(struct xdp_program *xdp_prog)
 	return xdp_prog->prog_id;
 }
 
-int xdp_program__print_chain_call_actions(struct xdp_program *prog,
+int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len)
 {
@@ -1758,8 +1758,8 @@ int xdp_multiprog__detach(struct xdp_multiprog *mp, int ifindex)
 }
 
 
-struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
-					     struct xdp_multiprog *mp)
+struct xdp_program *xdp_multiprog__next_prog(const struct xdp_program *prog,
+					     const struct xdp_multiprog *mp)
 {
 	if (!mp)
 		return NULL;
@@ -1770,10 +1770,26 @@ struct xdp_program *xdp_multiprog__next_prog(struct xdp_program *prog,
 	return mp->first_prog;
 }
 
-enum xdp_attach_mode xdp_multiprog__attach_mode(struct xdp_multiprog *mp)
+enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp)
 {
 	if (!mp)
 		return XDP_MODE_UNSPEC;
 
 	return mp->attach_mode;
+}
+
+uint32_t xdp_multiprog__dispatcher_id(const struct xdp_multiprog *mp)
+{
+	if (!mp)
+		return 0;
+
+	return xdp_program__id(mp->dispatcher);
+}
+
+const unsigned char *xdp_multiprog__dispatcher_tag(const struct xdp_multiprog *mp)
+{
+	if (!mp)
+		return 0;
+
+	return xdp_program__tag(mp->dispatcher);
 }

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -20,6 +20,7 @@ LIBXDP_0.0.3 {
 		xdp_program__from_fd;
 		xdp_program__from_id;
 		xdp_program__from_pin;
+		xdp_program__fd;
 		xdp_program__id;
 		xdp_program__is_attached;
 		xdp_program__name;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -5,8 +5,7 @@ LIBXDP_0.0.3 {
 		xdp_multiprog__attach_mode;
 		xdp_multiprog__close;
 		xdp_multiprog__detach;
-		xdp_multiprog__dispatcher_id;
-		xdp_multiprog__dispatcher_tag;
+		xdp_multiprog__dispatcher;
 		xdp_multiprog__get_from_ifindex;
 		xdp_multiprog__next_prog;
 		xdp_program__attach;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -20,9 +20,12 @@ LIBXDP_0.0.3 {
 		xdp_program__from_bpf_obj;
 		xdp_program__from_fd;
 		xdp_program__from_id;
+		xdp_program__from_pin;
 		xdp_program__id;
+		xdp_program__is_attached;
 		xdp_program__name;
 		xdp_program__open_file;
+		xdp_program__pin;
 		xdp_program__print_chain_call_actions;
 		xdp_program__run_prio;
 		xdp_program__set_chain_call_enabled;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -1,18 +1,29 @@
 LIBXDP_0.0.3 {
 	global:
-		xdp_multiprog__attach;
-		xdp_multiprog__free;
-		xdp_multiprog__generate;
+		libxdp_get_error;
+		libxdp_strerror;
+		xdp_multiprog__attach_mode;
+		xdp_multiprog__close;
+		xdp_multiprog__detach;
 		xdp_multiprog__get_from_ifindex;
+		xdp_multiprog__next_prog;
+		xdp_program__attach;
+		xdp_program__attach_multi;
+		xdp_program__bpf_obj;
 		xdp_program__chain_call_enabled;
-		xdp_program__free;
+		xdp_program__close;
+		xdp_program__detach;
+		xdp_program__detach_multi;
+		xdp_program__find_file;
 		xdp_program__from_bpf_obj;
 		xdp_program__from_fd;
 		xdp_program__from_id;
+		xdp_program__id;
 		xdp_program__name;
 		xdp_program__open_file;
 		xdp_program__print_chain_call_actions;
 		xdp_program__run_prio;
 		xdp_program__set_chain_call_enabled;
 		xdp_program__set_run_prio;
+		xdp_program__tag;
 };

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -5,6 +5,8 @@ LIBXDP_0.0.3 {
 		xdp_multiprog__attach_mode;
 		xdp_multiprog__close;
 		xdp_multiprog__detach;
+		xdp_multiprog__dispatcher_id;
+		xdp_multiprog__dispatcher_tag;
 		xdp_multiprog__get_from_ifindex;
 		xdp_multiprog__next_prog;
 		xdp_program__attach;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -11,6 +11,7 @@ LIBXDP_0.0.3 {
 		xdp_program__attach;
 		xdp_program__attach_multi;
 		xdp_program__bpf_obj;
+		xdp_program__btf;
 		xdp_program__chain_call_enabled;
 		xdp_program__close;
 		xdp_program__detach;

--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -32,7 +32,7 @@ static volatile const struct xdp_dispatcher_config conf = {};
 forloop(`i', `0', NUM_PROGS,
 `__attribute__ ((noinline))
 int format(`prog%d', i)(struct xdp_md *ctx) {
-        volatile int ret = XDP_PASS;
+        volatile int ret = XDP_DISPATCHER_RETVAL;
 
         if (!ctx)
           return XDP_ABORTED;
@@ -50,7 +50,7 @@ forloop(`i', `0', NUM_PROGS,
         if (num_progs_enabled < incr(i))
                 goto out;
         ret = format(`prog%d', i)(ctx);
-        if (!((1 << ret) & conf.chain_call_actions[i]))
+        if (!((1U << ret) & conf.chain_call_actions[i]))
                 return ret;
 ')
 out:

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -20,7 +20,7 @@
 #include "util.h"
 #include "logging.h"
 
-int check_snprintf(char *buf, size_t buf_len, const char *format, ...)
+int try_snprintf(char *buf, size_t buf_len, const char *format, ...)
 {
 	va_list args;
 	int len;
@@ -82,7 +82,7 @@ int find_bpf_file(char *buf, size_t buf_size, const char *progname)
 	int err;
 
 	for (path = bpf_obj_paths; *path; path++) {
-		err = check_snprintf(buf, buf_size, "%s/%s", *path, progname);
+		err = try_snprintf(buf, buf_size, "%s/%s", *path, progname);
 		if (err)
 			return err;
 
@@ -143,7 +143,7 @@ int make_dir_subdir(const char *parent, const char *dir)
 	char path[PATH_MAX];
 	int err;
 
-	err = check_snprintf(path, sizeof(path), "%s/%s", parent, dir);
+	err = try_snprintf(path, sizeof(path), "%s/%s", parent, dir);
 	if (err)
 		return err;
 
@@ -180,8 +180,8 @@ int attach_xdp_program(struct xdp_program *prog, const struct iface *iface,
 		return err;
 	}
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s/%s",
-			     pin_root_path, iface->ifname,
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s/%s",
+			   pin_root_path, iface->ifname,
 			     xdp_program__name(prog));
 	if (err)
 		return err;
@@ -220,9 +220,9 @@ int detach_xdp_program(struct xdp_program *prog, const struct iface *iface,
 	if (err)
 		goto out;
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s/%s",
-			     pin_root_path, iface->ifname,
-			     xdp_program__name(prog));
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s/%s",
+			   pin_root_path, iface->ifname,
+			   xdp_program__name(prog));
 	if (err)
 		return err;
 
@@ -230,9 +230,9 @@ int detach_xdp_program(struct xdp_program *prog, const struct iface *iface,
 	if (err && errno != ENOENT)
 		goto out;
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
-			     pin_root_path, iface->ifname,
-			     xdp_program__name(prog));
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
+			   pin_root_path, iface->ifname,
+			   xdp_program__name(prog));
 	if (err)
 		goto out;
 
@@ -255,8 +255,8 @@ int get_pinned_program(const struct iface *iface, const char *pin_root_path,
 	struct dirent *de;
 	DIR *dr;
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
-			     pin_root_path, iface->ifname);
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
+			   pin_root_path, iface->ifname);
 	if (err)
 		return err;
 
@@ -279,9 +279,9 @@ int get_pinned_program(const struct iface *iface, const char *pin_root_path,
 		    !strcmp("..", de->d_name))
 			continue;
 
-		err = check_snprintf(pin_path, sizeof(pin_path),
-				     "%s/programs/%s/%s", pin_root_path,
-				     iface->ifname, de->d_name);
+		err = try_snprintf(pin_path, sizeof(pin_path),
+				   "%s/programs/%s/%s", pin_root_path,
+				   iface->ifname, de->d_name);
 		if (err)
 			goto out;
 
@@ -329,8 +329,8 @@ int iterate_pinned_programs(const char *pin_root_path,
 	int err = 0;
 	DIR *dr;
 
-	err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs",
-			     pin_root_path);
+	err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs",
+			   pin_root_path);
 	if (err)
 		return err;
 
@@ -350,8 +350,8 @@ int iterate_pinned_programs(const char *pin_root_path,
 		iface.ifname = de->d_name;
 		iface.ifindex = if_nametoindex(iface.ifname);
 
-		err = check_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
-				     pin_root_path, iface.ifname);
+		err = try_snprintf(pin_path, sizeof(pin_path), "%s/programs/%s",
+				   pin_root_path, iface.ifname);
 		if (err)
 			goto out;
 
@@ -538,9 +538,9 @@ int get_bpf_root_dir(char *buf, size_t buf_len, const char *subdir)
 	}
 
 	if (subdir)
-		return check_snprintf(buf, buf_len, "%s/%s", bpf_dir, subdir);
+		return try_snprintf(buf, buf_len, "%s/%s", bpf_dir, subdir);
 	else
-		return check_snprintf(buf, buf_len, "%s", bpf_dir);
+		return try_snprintf(buf, buf_len, "%s", bpf_dir);
 }
 
 int get_pinned_map_fd(const char *bpf_root, const char *map_name,
@@ -550,7 +550,7 @@ int get_pinned_map_fd(const char *bpf_root, const char *map_name,
 	char buf[PATH_MAX];
 	int err;
 
-	err = check_snprintf(buf, sizeof(buf), "%s/%s", bpf_root, map_name);
+	err = try_snprintf(buf, sizeof(buf), "%s/%s", bpf_root, map_name);
 	if (err)
 		return err;
 
@@ -683,8 +683,8 @@ int prog_lock_get(const char *progname)
 	}
 
 	if (!prog_lock_file) {
-		err = check_snprintf(buf, sizeof(buf), "%s/%s.lck", lock_dir,
-				     progname);
+		err = try_snprintf(buf, sizeof(buf), "%s/%s.lck", lock_dir,
+				   progname);
 		if (err)
 			return err;
 

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -478,7 +478,6 @@ static const char *bpf_find_mntpt(const char *fstype, unsigned long magic,
 
 static int bpf_mnt_check_target(const char *target)
 {
-	struct stat sb = {};
 	int ret;
 
 	ret = mkdir(target, S_IRWXU);

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -710,7 +710,7 @@ int prog_lock_get(const char *progname)
 	if (prog_lock_fd < 0) {
 		err = -errno;
 		if (err == -EEXIST) {
-			unsigned long pid;
+			unsigned long pid = 0;
 			char buf[100];
 			ssize_t len;
 			int fd;
@@ -723,11 +723,12 @@ int prog_lock_get(const char *progname)
 				return err;
 			}
 
-			len = read(fd, buf, sizeof(buf));
+			len = read(fd, buf, sizeof(buf)-1);
 			close(fd);
-			buf[len] = '\0';
-
-			pid = strtoul(buf, NULL, 10);
+			if (len > 0) {
+				buf[len] = '\0';
+				pid = strtoul(buf, NULL, 10);
+			}
 			if (!pid) {
 				err = -errno;
 				pr_warn("Unable to read PID from lockfile: %s\n",

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -727,7 +727,7 @@ int prog_lock_get(const char *progname)
 				buf[len] = '\0';
 				pid = strtoul(buf, NULL, 10);
 			}
-			if (!pid) {
+			if (!pid || errno) {
 				err = -errno;
 				pr_warn("Unable to read PID from lockfile: %s\n",
 					strerror(-err));

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -121,50 +121,6 @@ out:
 	return err;
 }
 
-int find_bpf_file(char *buf, size_t buf_size, const char *progname)
-{
-	static char *bpf_obj_paths[] = {
-#ifdef DEBUG
-		".",
-#endif
-		BPF_OBJECT_PATH,
-		NULL
-	};
-	struct stat sb = {};
-	char **path;
-	int err;
-
-	for (path = bpf_obj_paths; *path; path++) {
-		err = check_snprintf(buf, buf_size, "%s/%s", *path, progname);
-		if (err)
-			return err;
-
-		pr_debug("Looking for '%s'\n", buf);
-		err = stat(buf, &sb);
-		if (err)
-			continue;
-
-		return 0;
-	}
-
-	pr_warn("Couldn't find a BPF file with name %s\n", progname);
-	return -ENOENT;
-}
-
-struct bpf_object *open_bpf_file(const char *progname,
-                                 struct bpf_object_open_opts *opts)
-{
-	char buf[PATH_MAX];
-	int err;
-
-	err = find_bpf_file(buf, sizeof(buf), progname);
-	if (err)
-		return ERR_PTR(err);
-
-	pr_debug("Loading bpf file '%s' from '%s'\n", progname, buf);
-	return bpf_object__open_file(buf, opts);
-}
-
 static int get_pinned_object_fd(const char *path, void *info, __u32 *info_len)
 {
 	char errmsg[STRERR_BUFSIZE];

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -385,7 +385,7 @@ int iterate_iface_multiprogs(multiprog_callback cb, void *arg)
 	if (!indexes) {
 		err = -errno;
 		pr_warn("Couldn't get list of interfaces: %s\n", strerror(-err));
-		goto out;
+		return err;
 	}
 
 	for (idx = indexes; idx->if_index; idx++){
@@ -411,6 +411,7 @@ int iterate_iface_multiprogs(multiprog_callback cb, void *arg)
 	}
 
 out:
+	if_freenameindex(indexes);
 	return err;
 }
 

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -339,9 +339,9 @@ int iterate_pinned_programs(const char *pin_root_path,
 		return -ENOENT;
 
 	while ((de = readdir(dr)) != NULL) {
-		struct xdp_program *prog;
+		enum xdp_attach_mode mode = XDP_MODE_UNSPEC;
+		struct xdp_program *prog = NULL;
 		struct iface iface = {};
-		enum xdp_attach_mode mode;
 
 		if (!strcmp(".", de->d_name) ||
 		    !strcmp("..", de->d_name))

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -553,7 +553,7 @@ out:
 	return err;
 }
 
-int iterate_iface_programs_all(program_callback cb, void *arg)
+int iterate_iface_multiprogs(multiprog_callback cb, void *arg)
 {
 	struct if_nameindex *idx, *indexes = NULL;
 	int err = 0;

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -481,13 +481,11 @@ static int bpf_mnt_check_target(const char *target)
 	struct stat sb = {};
 	int ret;
 
-	ret = stat(target, &sb);
-	if (ret) {
-		ret = mkdir(target, S_IRWXU);
-		if (ret) {
-			pr_warn("mkdir %s failed: %s\n", target, strerror(errno));
-			return ret;
-		}
+	ret = mkdir(target, S_IRWXU);
+	if (ret && errno != EEXIST) {
+		ret = -errno;
+		pr_warn("mkdir %s failed: %s\n", target, strerror(-ret));
+		return ret;
 	}
 
 	return 0;

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -58,9 +58,6 @@ int make_dir_subdir(const char *parent, const char *dir);
 int check_bpf_environ(const char *pin_root_path);
 int double_rlimit();
 
-int find_bpf_file(char *buf, size_t buf_size, const char *progname);
-struct bpf_object *open_bpf_file(const char *progname,
-                                 struct bpf_object_open_opts *opts);
 int load_bpf_object(struct bpf_object *obj, bool raise_rlimit);
 int attach_xdp_program(const struct bpf_object *obj, const char *prog_name,
                        const struct iface *iface, bool force,

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -52,7 +52,7 @@
 )
 #endif
 
-int check_snprintf(char *buf, size_t buf_len, const char *format, ...);
+int try_snprintf(char *buf, size_t buf_len, const char *format, ...);
 int make_dir_subdir(const char *parent, const char *dir);
 
 int check_bpf_environ(const char *pin_root_path);

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -65,8 +65,7 @@ int attach_xdp_program(const struct bpf_object *obj, const char *prog_name,
 int detach_xdp_program(const struct iface *iface, const char *pin_root_dir);
 
 typedef int (*program_callback)(const struct iface *iface,
-                                const struct bpf_prog_info *info,
-                                enum xdp_attach_mode mode,
+                                const struct xdp_multiprog *mp,
                                 void *arg);
 int get_pinned_program(const struct iface *iface, const char *pin_root_path,
                        char *prog_name, size_t prog_name_len,
@@ -76,8 +75,7 @@ int get_loaded_program(const struct iface *iface, enum xdp_attach_mode *mode,
                        struct bpf_prog_info *info);
 int iterate_iface_programs_pinned(const char *pin_root_path, program_callback cb,
                                   void *arg);
-int iterate_iface_programs_all(const char *pin_root_path, program_callback cb,
-                               void *arg);
+int iterate_iface_programs_all(program_callback cb, void *arg);
 
 int get_xdp_prog_info(const struct iface *iface, struct bpf_prog_info *info,
                       enum xdp_attach_mode *mode, const char *pin_root_path);

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -63,6 +63,10 @@ int attach_xdp_program(struct xdp_program *prog, const struct iface *iface,
 int detach_xdp_program(struct xdp_program *prog, const struct iface *iface,
                        enum xdp_attach_mode mode, const char *pin_root_dir);
 
+int find_bpf_file(char *buf, size_t buf_size, const char *progname);
+struct bpf_object *open_bpf_file(const char *progname,
+                                 struct bpf_object_open_opts *opts);
+
 typedef int (*program_callback)(const struct iface *iface,
                                 struct xdp_program *prog,
                                 enum xdp_attach_mode mode,

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -58,27 +58,25 @@ int make_dir_subdir(const char *parent, const char *dir);
 int check_bpf_environ(const char *pin_root_path);
 int double_rlimit();
 
-int load_bpf_object(struct bpf_object *obj, bool raise_rlimit);
-int attach_xdp_program(const struct bpf_object *obj, const char *prog_name,
-                       const struct iface *iface, bool force,
+int attach_xdp_program(struct xdp_program *prog, const struct iface *iface,
                        enum xdp_attach_mode mode, const char *pin_root_dir);
-int detach_xdp_program(const struct iface *iface, const char *pin_root_dir);
+int detach_xdp_program(struct xdp_program *prog, const struct iface *iface,
+                       enum xdp_attach_mode mode, const char *pin_root_dir);
 
 typedef int (*program_callback)(const struct iface *iface,
-                                const struct xdp_multiprog *mp,
+                                struct xdp_program *prog,
+                                enum xdp_attach_mode mode,
                                 void *arg);
-int get_pinned_program(const struct iface *iface, const char *pin_root_path,
-                       char *prog_name, size_t prog_name_len,
-                       enum xdp_attach_mode *mode,
-                       struct bpf_prog_info *info);
-int get_loaded_program(const struct iface *iface, enum xdp_attach_mode *mode,
-                       struct bpf_prog_info *info);
-int iterate_iface_programs_pinned(const char *pin_root_path, program_callback cb,
+typedef int (*multiprog_callback)(const struct iface *iface,
+                                  const struct xdp_multiprog *mp,
                                   void *arg);
+int get_pinned_program(const struct iface *iface, const char *pin_root_path,
+                       enum xdp_attach_mode *mode,
+                       struct xdp_program **prog);
+int iterate_pinned_programs(const char *pin_root_path, program_callback cb,
+                            void *arg);
 int iterate_iface_multiprogs(multiprog_callback cb, void *arg);
 
-int get_xdp_prog_info(const struct iface *iface, struct bpf_prog_info *info,
-                      enum xdp_attach_mode *mode, const char *pin_root_path);
 int get_bpf_root_dir(char *buf, size_t buf_len, const char *subdir);
 int get_pinned_map_fd(const char *bpf_root, const char *map_name,
                       struct bpf_map_info *info);

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -4,6 +4,7 @@
 #define __UTIL_H
 
 #include <bpf/libbpf.h>
+#include <xdp/libxdp.h>
 #include "params.h"
 
 #ifndef PATH_MAX
@@ -50,13 +51,6 @@
 }                                        \
 )
 #endif
-
-enum xdp_attach_mode {
-                      XDP_MODE_UNSPEC = 0,
-                      XDP_MODE_NATIVE,
-                      XDP_MODE_SKB,
-                      XDP_MODE_HW
-};
 
 int check_snprintf(char *buf, size_t buf_len, const char *format, ...);
 int make_dir_subdir(const char *parent, const char *dir);

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -75,7 +75,7 @@ int get_loaded_program(const struct iface *iface, enum xdp_attach_mode *mode,
                        struct bpf_prog_info *info);
 int iterate_iface_programs_pinned(const char *pin_root_path, program_callback cb,
                                   void *arg);
-int iterate_iface_programs_all(program_callback cb, void *arg);
+int iterate_iface_multiprogs(multiprog_callback cb, void *arg);
 
 int get_xdp_prog_info(const struct iface *iface, struct bpf_prog_info *info,
                       enum xdp_attach_mode *mode, const char *pin_root_path);

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -591,7 +591,7 @@ rlimit_loop:
 	err = libbpf_get_error(trace_obj);
 	if (err) {
 		pr_warn("ERROR: Can't open XDP trace program: %s(%d)\n",
-			strerror(err), err);
+			strerror(-err), err);
 		trace_obj = NULL;
 		goto error_exit;
 	}
@@ -744,7 +744,7 @@ rlimit_loop:
 		err = perf_buffer__poll(perf_buf, 1000);
 		if (err < 0 && err != -EINTR) {
 			pr_warn("ERROR: Perf buffer polling failed: %s(%d)",
-				strerror(err), err);
+				strerror(-err), err);
 			goto error_exit;
 		}
 	}

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -813,7 +813,7 @@ static bool list_interfaces(struct dumpopt *cfg)
 			       xdp_program__name(xdp_multiprog__main_prog(mp)));
 
 			while ((prog = xdp_multiprog__next_prog(prog, mp)))
-				printf("%-25s %s()\n", "=>",
+				printf("%-29s %s()\n", "=>",
 				       xdp_program__name(prog));
 
 			xdp_multiprog__close(mp);

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -416,6 +416,9 @@ error_exit:
 	return rc;
 }
 
+/*****************************************************************************
+ * find_func_matches()
+ *****************************************************************************/
 static size_t find_func_matches(const struct btf *btf,
 				const char *func_name,
 				const char **found_name,
@@ -465,7 +468,7 @@ static size_t find_func_matches(const struct btf *btf,
 }
 
 /*****************************************************************************
- * find_target_program()
+ * find_target()
  *****************************************************************************/
 static int find_target(struct xdp_multiprog *mp,
 		       char *function_override,

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -425,7 +425,7 @@ static struct xdp_program *find_target_program(struct xdp_multiprog *mp,
 	struct xdp_program *prog = NULL;
 
 	if (!function_override)
-		return xdp_multiprog__dispatcher(mp);
+		return xdp_multiprog__main_prog(mp);
 
 	while ((prog = xdp_multiprog__next_prog(prog, mp)))
 		if (!strcmp(function_override, xdp_program__name(prog)))
@@ -704,7 +704,7 @@ static bool list_interfaces(struct dumpopt *cfg)
 
 			printf("%-8d  %-16.16s  %s()\n",
 			       idx->if_index, idx->if_name,
-			       xdp_program__name(xdp_multiprog__dispatcher(mp)));
+			       xdp_program__name(xdp_multiprog__main_prog(mp)));
 
 			while ((prog = xdp_multiprog__next_prog(prog, mp)))
 				printf("%-25s %s()\n", "=>",

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -813,7 +813,7 @@ static bool list_interfaces(struct dumpopt *cfg)
 			       xdp_program__name(xdp_multiprog__main_prog(mp)));
 
 			while ((prog = xdp_multiprog__next_prog(prog, mp)))
-				printf("%-29s %s()\n", "=>",
+				printf("%-29s %s()\n", "",
 				       xdp_program__name(prog));
 
 			xdp_multiprog__close(mp);

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -338,7 +338,7 @@ static int remove_unused_maps(const char *pin_root_path, __u32 features)
 		close(dir_fd);
 		dir_fd = -1;
 
-		err = check_snprintf(buf, sizeof(buf), "%s/%s", pin_root_path, "programs");
+		err = try_snprintf(buf, sizeof(buf), "%s/%s", pin_root_path, "programs");
 		pr_debug("Removing program directory %s\n", buf);
 		err = rmdir(buf);
 		if (err) {

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -362,6 +362,9 @@ static int remove_unused_maps(const char *pin_root_path, __u32 features)
 		dir_fd = -1;
 
 		err = try_snprintf(buf, sizeof(buf), "%s/%s", pin_root_path, "programs");
+		if (err)
+			goto out;
+
 		pr_debug("Removing program directory %s\n", buf);
 		err = rmdir(buf);
 		if (err) {
@@ -917,6 +920,8 @@ int do_status(const void *cfg, const char *pin_root_path)
 
 	err = iterate_pinned_programs(pin_root_path, print_iface_status,
 				      NULL);
+	if (err)
+		goto out;
 	printf("\n");
 
 	map_fd = get_pinned_map_fd(pin_root_path, textify(MAP_NAME_PORTS), NULL);

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -141,7 +141,6 @@ static const struct loadopt {
 	bool help;
 	struct iface iface;
 	unsigned int features;
-	bool force;
 	enum xdp_attach_mode mode;
 	bool whitelist_mode;
 } defaults_load = {
@@ -178,9 +177,6 @@ struct enum_val xdp_modes[] = {
 };
 
 static struct prog_option load_options[] = {
-	DEFINE_OPTION("force", OPT_BOOL, struct loadopt, force,
-		      .short_opt = 'F',
-		      .help = "Force loading of XDP program"),
 	DEFINE_OPTION("mode", OPT_ENUM, struct loadopt, mode,
 		      .short_opt = 'm',
 		      .typearg = xdp_modes,

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -902,9 +902,9 @@ int do_status(const void *cfg, const char *pin_root_path)
 		if (err)
 			goto out;
 		printf("\n");
+		close(map_fd);
+		map_fd = -1;
 	}
-	close(map_fd);
-	map_fd = -1;
 
 	err = print_ips(pin_root_path);
 	if (err)

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -26,7 +26,6 @@ static const struct loadopt {
 	struct multistring filenames;
 	char *pin_path;
 	char *section_name;
-	bool force;
 	enum xdp_attach_mode mode;
 } defaults_load = {
 	.mode = XDP_MODE_UNSPEC
@@ -41,9 +40,6 @@ struct enum_val xdp_modes[] = {
 
 
 static struct prog_option load_options[] = {
-	DEFINE_OPTION("force", OPT_BOOL, struct loadopt, force,
-		      .short_opt = 'F',
-		      .help = "Force loading of XDP program"),
 	DEFINE_OPTION("mode", OPT_ENUM, struct loadopt, mode,
 		      .short_opt = 'm',
 		      .typearg = xdp_modes,

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -252,9 +252,9 @@ int print_iface_status(const struct iface *iface,
 		       const struct xdp_multiprog *mp,
 		       void *arg)
 {
+	struct xdp_program *prog, *dispatcher;
 	char tag[BPF_TAG_SIZE*2+1];
 	char buf[STRERR_BUFSIZE];
-	struct xdp_program *prog;
 	int err;
 
 	if (!mp) {
@@ -263,13 +263,15 @@ int print_iface_status(const struct iface *iface,
 		return 0;
 	}
 
+	dispatcher = xdp_multiprog__dispatcher(mp);
+
 	printf("%-16s %-5s %-16s %-8s %-4d %-17s\n",
 	       iface->ifname,
 	       "",
 	       "",
 	       get_enum_name(xdp_modes, xdp_multiprog__attach_mode(mp)),
-	       xdp_multiprog__dispatcher_id(mp),
-	       print_bpf_tag(tag, xdp_multiprog__dispatcher_tag(mp)));
+	       xdp_program__id(dispatcher),
+	       print_bpf_tag(tag, xdp_program__tag(dispatcher)));
 
 
 	for (prog = xdp_multiprog__next_prog(NULL, mp);

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -86,7 +86,6 @@ int do_load(const void *cfg, const char *pin_root_path)
 		pr_warn("Couldn't allocate memory\n");
 		return EXIT_FAILURE;
 	}
-	memset(progs, 0, sizeof(*progs) * num_progs);
 
 	pr_debug("Loading %zu files on interface '%s'.\n",
 		 num_progs, opt->iface.ifname);

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -81,7 +81,7 @@ int do_load(const void *cfg, const char *pin_root_path)
 	}
 
 	num_progs = opt->filenames.num_strings;
-	progs = calloc(sizeof(*progs), num_progs);
+	progs = calloc(num_progs, sizeof(*progs));
 	if (!progs) {
 		pr_warn("Couldn't allocate memory\n");
 		return EXIT_FAILURE;
@@ -154,6 +154,7 @@ out:
 	for (i = 0; i < num_progs; i++)
 		if (progs[i])
 			xdp_program__close(progs[i]);
+	free(progs);
 	return err;
 }
 

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -305,7 +305,7 @@ int do_status(const void *cfg, const char *pin_root_path)
 	       "Interface", "Prio", "Program name", "Tag", "Chain actions");
 	printf("-------------------------------------------------------------------------------------\n");
 
-	err = iterate_iface_programs_all(print_iface_status, NULL);
+	err = iterate_iface_multiprogs(print_iface_status, NULL);
 	printf("\n");
 
 	return err;

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -203,8 +203,11 @@ int do_unload(const void *cfg, const char *pin_root_path)
 
 	if (opt->all) {
 		err = xdp_multiprog__detach(mp, opt->iface.ifindex);
-		if (err)
+		if (err) {
+			pr_warn("Unable to detach XDP program: %s\n",
+				strerror(-err));
 			goto out;
+		}
 	} else {
 		struct xdp_program *prog = NULL;
 
@@ -213,14 +216,20 @@ int do_unload(const void *cfg, const char *pin_root_path)
 				break;
 		}
 		if (!prog) {
-			pr_warn("Program with ID %u no loaded on %s\n",
+			pr_warn("Program with ID %u not loaded on %s\n",
 				opt->prog_id, opt->iface.ifname);
+			err = -ENOENT;
 			goto out;
 		}
+		pr_debug("Detaching XDP program with ID %u from %s\n",
+			 xdp_program__id(prog), opt->iface.ifname);
 		err = xdp_program__detach(prog, opt->iface.ifindex,
 					  XDP_MODE_UNSPEC);
-		if (err)
+		if (err) {
+			pr_warn("Unable to detach XDP program: %s\n",
+				strerror(-err));
 			goto out;
+		}
 	}
 
 out:

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -197,7 +197,9 @@ int do_unload(const void *cfg, const char *pin_root_path)
 		goto out;
 	}
 
-	if (opt->all) {
+	if (opt->all || (xdp_multiprog__is_legacy(mp) &&
+			 (xdp_program__id(xdp_multiprog__main_prog(mp)) ==
+			  opt->prog_id))) {
 		err = xdp_multiprog__detach(mp, opt->iface.ifindex);
 		if (err) {
 			pr_warn("Unable to detach XDP program: %s\n",
@@ -263,12 +265,12 @@ int print_iface_status(const struct iface *iface,
 		return 0;
 	}
 
-	dispatcher = xdp_multiprog__dispatcher(mp);
+	dispatcher = xdp_multiprog__main_prog(mp);
 
 	printf("%-16s %-5s %-16s %-8s %-4d %-17s\n",
 	       iface->ifname,
 	       "",
-	       "",
+	       xdp_program__name(dispatcher),
 	       get_enum_name(xdp_modes, xdp_multiprog__attach_mode(mp)),
 	       xdp_program__id(dispatcher),
 	       print_bpf_tag(tag, xdp_program__tag(dispatcher)));


### PR DESCRIPTION
This is a rework of the libxdp API to avoid exposing the multiprog and
dispatcher internals, and instead have xdp_program-based attach and detach
functions, so we can have some freedom to change the internals without having to
touch the API.

This also reworks the lib/util functions to build on top of libxdp, and ports
all the command-line utilities to use it.

While I have runtime-tested xdp-loader, the other utilities are only compile
tested.