### PR TITLE
xdp-dump: on an exact match of bpf function do not accept partials

### DIFF
--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -467,6 +467,9 @@ static size_t find_func_matches(const struct btf *btf,
 		}
 	}
 
+	if (exact)
+		return 0;
+
 	if (matches == 1)
 		*found_name = btf__name_by_offset(btf, match->name_off);
 


### PR DESCRIPTION
Signed-off-by: Eelco Chaudron <echaudro@redhat.com>