### PR TITLE
lib/util: Fix skipping of keys while iterating map

### DIFF
--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -189,7 +189,7 @@ int attach_xdp_program(struct xdp_program *prog, const struct iface *iface,
 
 	err = xdp_program__attach(prog, iface->ifindex, mode);
 	if (err) {
-		if (pin_root_path)
+		if (pin_root_path && err != -EEXIST)
 			unlink(pin_path);
 		return err;
 	}

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -27,8 +27,8 @@
 #define FOR_EACH_MAP_KEY(_err, _map_fd, _map_key, _next_key)            \
   for(_err = bpf_map_get_next_key(_map_fd, NULL, &_next_key);           \
       !_err;                                                            \
-      _err = bpf_map_get_next_key(_map_fd, &_map_key, &_next_key),      \
-        _map_key = _next_key)
+      _map_key = _next_key,                                             \
+        _err = bpf_map_get_next_key(_map_fd, &_map_key, &_next_key)) 
 
 #define min(x,y) ((x)<(y) ? x : y)
 #define max(x,y) ((x)>(y) ? x : y)


### PR DESCRIPTION
Sometimes an added address was not printed out by the status subcommand, even though it was filtered correctly.