### PR TITLE
xdp-filter: Fix printing of filtered MAC addresses

### DIFF
--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -935,7 +935,7 @@ int do_status(const void *cfg, const char *pin_root_path)
 	}
 
 	err = print_ips(pin_root_path);
-	if (err)
+	if (err && err != -ENOENT)
 		goto out;
 
 	printf("\n");


### PR DESCRIPTION
If the filter was loaded with a feature set not containing ip, status
subcommand did not print out the filtered MAC addresses.

Signed-off-by: Štěpán Horáček <shoracek@redhat.com>