### PR TITLE
lib/util: Fix skipping of the last key in map

### DIFF
--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -24,11 +24,11 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
 
-#define FOR_EACH_MAP_KEY(_err, _map_fd, _map_key, _next_key)                \
-	for (_err = bpf_map_get_next_key(_map_fd, NULL, &_next_key);        \
+#define FOR_EACH_MAP_KEY(_err, _map_fd, _map_key, _prev_key)                \
+	for (_err = bpf_map_get_next_key(_map_fd, NULL, &_map_key);         \
              !_err;                                                         \
-	     _map_key = _next_key,                                          \
-	    _err = bpf_map_get_next_key(_map_fd, &_map_key, &_next_key))
+	     _prev_key = _map_key,                                          \
+	    _err = bpf_map_get_next_key(_map_fd, &_prev_key, &_map_key))
 
 #define min(x, y) ((x) < (y) ? x : y)
 #define max(x, y) ((x) > (y) ? x : y)

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -501,12 +501,12 @@ out:
 
 int print_ports(int map_fd)
 {
-	__u32 map_key = -1, next_key = 0;
+	__u32 map_key = -1, prev_key = 0;
 	int err;
 
 	printf("Filtered ports:\n");
 	printf("  %-40s Mode             Hit counter\n", "");
-	FOR_EACH_MAP_KEY (err, map_fd, map_key, next_key) {
+	FOR_EACH_MAP_KEY (err, map_fd, map_key, prev_key) {
 		char buf[100];
 		__u64 counter;
 		__u8 flags = 0;
@@ -618,10 +618,10 @@ out:
 
 int __print_ips(int map_fd, int af)
 {
-	struct ip_addr map_key = { .af = af }, next_key = {};
+	struct ip_addr map_key = { .af = af }, prev_key = {};
 	int err;
 
-	FOR_EACH_MAP_KEY (err, map_fd, map_key.addr, next_key.addr) {
+	FOR_EACH_MAP_KEY (err, map_fd, map_key.addr, prev_key.addr) {
 		char flagbuf[100], addrbuf[100];
 		__u8 flags = 0;
 		__u64 counter;
@@ -779,12 +779,12 @@ out:
 
 int print_ethers(int map_fd)
 {
-	struct mac_addr map_key = {}, next_key = {};
+	struct mac_addr map_key = {}, prev_key = {};
 	int err;
 
 	printf("Filtered MAC addresses:\n");
 	printf("  %-40s Mode             Hit counter\n", "");
-	FOR_EACH_MAP_KEY (err, map_fd, map_key, next_key) {
+	FOR_EACH_MAP_KEY (err, map_fd, map_key, prev_key) {
 		char modebuf[100], addrbuf[100];
 		__u8 flags = 0;
 		__u64 counter;


### PR DESCRIPTION
After commit aef3cac the last key was still skipped.