### PR TITLE
xdp-filters: fixed self test issue with tcpdump

### DIFF
--- a/xdp-filter/test-xdp-filter.sh
+++ b/xdp-filter/test-xdp-filter.sh
@@ -59,9 +59,8 @@ check_packet()
     local command="$2"
     local expect="$3"
     echo "Checking command '$command' filter '$filter'"
-    PID=$(start_background tcpdump -epni $NS "$filter")
+    PID=$(start_background tcpdump --immediate-mode -epni $NS "$filter")
     echo "Started listener as $PID"
-    sleep 1
     ns_exec bash -c "$command"
     sleep 1
     output=$(stop_background $PID)


### PR DESCRIPTION
Some times tcpdump gets terminated before it finishing reading the
buffers from the kernel. Rather than increasing the timeout, add the
"--immediate-mode" option to not delay any packet gathering.

In addition also removed the first 1 second delay, as it's already
part of the start_background shell function.

Signed-off-by: Eelco Chaudron <echaudro@redhat.com>