### PR TITLE
libxdp: Fix installing without supported Emacs

### DIFF
--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -51,8 +51,8 @@ install: all
 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
 	$(Q)install -m 0755 $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
 	$(Q)install -m 0755 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
-	$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3
-	$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3
+	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
 
 
 $(OBJDIR)/libxdp.a: $(STATIC_OBJS)


### PR DESCRIPTION
Makefile fails and prints
```
install: missing destination file operand after '/usr/local/share/man/man3'
Try 'install --help' for more information.
```
while installing without proper Emacs, since the MAN_FILES variable was empty.