### PR TITLE
xdp-loader: Change to loading programs in native mode by default

### DIFF
--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -48,8 +48,12 @@ The supported options are:
 ** -m, --mode <mode>
 Specifies which mode to load the XDP program to be loaded in. The valid values
 are 'native', which is the default in-driver XDP mode, 'skb', which causes the
-so-called /skb mode/ (also known as /generic XDP/) to be used, or 'hw' which
-causes the program to be offloaded to the hardware.
+so-called /skb mode/ (also known as /generic XDP/) to be used, 'hw' which causes
+the program to be offloaded to the hardware, or 'unspecified' which leaves it up
+to the kernel to pick a mode (which it will do by picking native mode if the
+driver supports it, or generic mode otherwise). Note that using 'unspecified'
+can make it difficult to predict what mode a program will end up being loaded
+in. For this reason, the default is 'native'.
 
 ** -p, --pin-path <path>
 This specifies a root path under which to pin any maps that define the 'pinning'

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -27,13 +27,14 @@ static const struct loadopt {
 	char *section_name;
 	enum xdp_attach_mode mode;
 } defaults_load = {
-	.mode = XDP_MODE_UNSPEC
+	.mode = XDP_MODE_NATIVE
 };
 
 struct enum_val xdp_modes[] = {
        {"native", XDP_MODE_NATIVE},
        {"skb", XDP_MODE_SKB},
        {"hw", XDP_MODE_HW},
+       {"unspecified", XDP_MODE_UNSPEC},
        {NULL, 0}
 };
 
@@ -43,7 +44,7 @@ static struct prog_option load_options[] = {
 		      .short_opt = 'm',
 		      .typearg = xdp_modes,
 		      .metavar = "<mode>",
-		      .help = "Load XDP program in <mode>; default unspecified"),
+		      .help = "Load XDP program in <mode>; default native"),
 	DEFINE_OPTION("pin-path", OPT_STRING, struct loadopt, pin_path,
 		      .short_opt = 'p',
 		      .help = "Path to pin maps under (must be in bpffs)."),
@@ -230,7 +231,7 @@ int do_unload(const void *cfg, const char *pin_root_path)
 		pr_debug("Detaching XDP program with ID %u from %s\n",
 			 xdp_program__id(prog), opt->iface.ifname);
 		err = xdp_program__detach(prog, opt->iface.ifindex,
-					  XDP_MODE_UNSPEC, 0);
+					  xdp_multiprog__attach_mode(mp), 0);
 		if (err) {
 			pr_warn("Unable to detach XDP program: %s\n",
 				strerror(-err));


### PR DESCRIPTION
Previously we were loading programs without specifying an explicit mode by
default, letting the kernel pick. This causes problems for a couple of
reasons:

- It causes silent fallback from native to generic mode, making it harder
  to predict which mode a program would be loaded in.

- There's an nfp driver bug which makes it harder to unload such programs.

Arguably, the default should have been to just load in native mode from the
start. So let's change the default, but let the user go back to the
kernel-picked mode by specifying '-m unspecified' when loading. Document
the change in defaults in the man page.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>


----

@shoracek discovered why the nfp driver was having issues with unloading programs.
Arguably we should have been using native mode from the beginning, but let's
discuss whether we should change it at this point.

@chaudron, @netoptimizer, @shoracek comments?