### PR TITLE
configure: add BPF_TARGET for cross-compile

### DIFF
--- a/configure
+++ b/configure
@@ -16,9 +16,11 @@ check_opts()
     : ${PRODUCTION:=0}
     : ${DYNAMIC_LIBXDP:=0}
     : ${MAX_DISPATCHER_ACTIONS:=10}
+    : ${BPF_TARGET:=bpf}
     echo "PRODUCTION:=${PRODUCTION}" >>$CONFIG
     echo "DYNAMIC_LIBXDP:=${DYNAMIC_LIBXDP}" >>$CONFIG
     echo "MAX_DISPATCHER_ACTIONS:=${MAX_DISPATCHER_ACTIONS}" >>$CONFIG
+    echo "BPF_TARGET:=${BPF_TARGET}" >>$CONFIG
 }
 
 check_toolchain()

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -106,7 +106,7 @@ $(USER_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OBJS) 
 
 $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target bpf \
+	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -115,7 +115,7 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=bpf -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
 
 .PHONY: man
 ifeq ($(EMACS),)

--- a/lib/defines.mk
+++ b/lib/defines.mk
@@ -1,5 +1,6 @@
 CFLAGS ?= -O2 -g
 BPF_CFLAGS ?= -Wno-visibility
+BPF_TARGET ?= bpf
 
 include $(LIB_DIR)/../config.mk
 include $(LIB_DIR)/../version.mk
@@ -47,4 +48,3 @@ BPF_CFLAGS += $(DEFINES)
 
 CONFIGMK := $(LIB_DIR)/../config.mk
 LIBMK := Makefile $(CONFIGMK) $(LIB_DIR)/defines.mk $(LIB_DIR)/common.mk $(LIB_DIR)/../version.mk
-

--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -127,7 +127,7 @@ $(TEMPLATED_SOURCES): %.c: %.c.in Makefile
 
 $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target bpf \
+	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -136,7 +136,7 @@ $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=bpf -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
 
 .PHONY: man
 ifeq ($(EMACS),)


### PR DESCRIPTION
Although we cross-compile, we use clang from the host. Setting
"-target=bpf" will result in the right format for the host system but
not for the actual target.

Clang has the feature that we can also cross compile directly for some
other architecture, i.e. we can use "bpfeb" and "bpfel".

If we want to use e.g. OpenWrt, then we would like to be able to compile
directly for the given architecture. OpenWrt has the nice feature
that we can check in the Makefile for "ifeq ($(CONFIG_BIG_ENDIAN),y)".
If we combine both, we can set the endianness automatically.

The default behavior remains by setting "-target=bpf".