### PR TITLE
Support incremental attach and detach of subprograms

### DIFF
--- a/configure
+++ b/configure
@@ -184,6 +184,7 @@ int main(int argc, char **argv) {
     void *ptr;
     DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts, .pin_root_path = "/path");
     DECLARE_LIBBPF_OPTS(bpf_xdp_set_link_opts, lopts, .old_fd = -1);
+    DECLARE_LIBBPF_OPTS(bpf_link_create_opts, lopts, .target_btf_id = 0);
     (void) bpf_object__open_file("file", &opts);
     (void) bpf_program__name(ptr);
     (void) bpf_map__set_initial_value(ptr, ptr, 0);

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -123,7 +123,7 @@ check_prereq()
         die "This script needs root permissions to run."
     fi
 
-    STATEDIR="$(mktemp -d --tmpdir=${TMPDIR:-/tmp} --suffix=.xdptest)" 
+    STATEDIR="$(mktemp -d --tmpdir=${TMPDIR:-/tmp} --suffix=.xdptest)"
     if [ $? -ne 0 ]; then
         die "Unable to create state dir in $TMPDIR"
     fi
@@ -385,6 +385,8 @@ is_func()
 
 check_run()
 {
+    local ret
+
     "$@"
     ret=$?
     if [ "$ret" -ne "0" ]; then

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -92,6 +92,6 @@ int prog_lock_get(const char *progname);
 void prog_lock_release(int signal);
 
 const char *get_libbpf_version(void);
-int iface_print_status(void);
+int iface_print_status(const struct iface *iface);
 
 #endif

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -1848,7 +1848,7 @@ int main(int argc, char **argv)
 
 	/* See if we need to dump interfaces and exit */
 	if (cfg_dumpopt.list_interfaces) {
-		if (iface_print_status())
+		if (iface_print_status(NULL))
 			return EXIT_SUCCESS;
 		return EXIT_FAILURE;
 	}

--- a/xdp-loader/tests/test-xdp-loader.sh
+++ b/xdp-loader/tests/test-xdp-loader.sh
@@ -1,5 +1,5 @@
 XDP_LOADER=${XDP_LOADER:-./xdp-loader}
-ALL_TESTS="test_load test_section"
+ALL_TESTS="test_load test_section test_load_multi test_load_incremental"
 
 test_load()
 {
@@ -11,6 +11,56 @@ test_section()
 {
     check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o -s xdp -vv
     check_run $XDP_LOADER unload $NS --all -vv
+}
+
+check_progs_loaded()
+{
+    local iface="$1"
+    local num=$2
+    local num_loaded
+
+    num_loaded=$($XDP_LOADER status $NS | grep -c '=>')
+    if [ "$num_loaded" -ne "$num" ]; then
+        echo "Expected $num programs loaded, found $num_loaded"
+        exit 1
+    fi
+}
+
+test_load_multi()
+{
+    check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o $TEST_PROG_DIR/xdp_pass.o -vv
+    check_progs_loaded $NS 2
+    check_run $XDP_LOADER unload $NS --all -vv
+}
+
+test_load_incremental()
+{
+    local output
+    local ret
+    local id
+
+    check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o -vv
+
+    check_progs_loaded $NS 1
+
+    output=$($XDP_LOADER load $NS $TEST_PROG_DIR/xdp_pass.o -vv)
+    ret=$?
+
+    if [ "$ret" -ne "0" ] && echo $output | grep -q "Falling back to loading single prog"; then
+        ret=$SKIPPED_TEST
+        check_run $XDP_LOADER unload $NS --all -vv
+    else
+        check_progs_loaded $NS 2
+
+        id=$($XDP_LOADER status $NS | grep xdp_pass | awk '{print $4}')
+        check_run $XDP_LOADER unload $NS --id $id
+        check_progs_loaded $NS 1
+
+        id=$($XDP_LOADER status $NS | grep xdp_drop | awk '{print $4}')
+        check_run $XDP_LOADER unload $NS --id $id
+        check_progs_loaded $NS 0
+    fi
+    return $ret
 }
 
 cleanup_tests()

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -259,12 +259,23 @@ out:
 	return err ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
-static struct prog_option status_options[] = { END_OPTIONS };
+static const struct statusopt {
+	struct iface iface;
+} defaults_status = {};
 
-int do_status(__unused const void *cfg, __unused const char *pin_root_path)
+static struct prog_option status_options[] = {
+	DEFINE_OPTION("dev", OPT_IFNAME, struct statusopt, iface,
+		      .positional = true, .metavar = "[ifname]",
+		      .help = "Show status for device [ifname] (default all interfaces)"),
+	END_OPTIONS
+};
+
+int do_status(const void *cfg, __unused const char *pin_root_path)
 {
+	const struct statusopt *opt = cfg;
+
 	printf("CURRENT XDP PROGRAM STATUS:\n\n");
-	return iface_print_status();
+	return iface_print_status(opt->iface.ifindex ? &opt->iface : NULL);
 }
 
 int do_help(__unused const void *cfg, __unused const char *pin_root_path)
@@ -285,7 +296,7 @@ int do_help(__unused const void *cfg, __unused const char *pin_root_path)
 static const struct prog_command cmds[] = {
 	DEFINE_COMMAND(load, "Load an XDP program on an interface"),
 	DEFINE_COMMAND(unload, "Unload an XDP program from an interface"),
-	DEFINE_COMMAND_NODEF(status, "Show XDP program status"),
+	DEFINE_COMMAND(status, "Show XDP program status"),
 	{ .name = "help", .func = do_help, .no_cfg = true },
 	END_COMMANDS
 };
@@ -293,6 +304,7 @@ static const struct prog_command cmds[] = {
 union all_opts {
 	struct loadopt load;
 	struct unloadopt unload;
+	struct statusopt status;
 };
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The kernel now supports re-attaching an freplace program in multiple
places, which means we can finally implement incremental loading of
multiprogs. This involves no change in the API, it just means that
attaching a program to an interface that already has program(s) attached
now will work if the kernel is new enough (5.10+).

This also means we can support detaching a subset of the programs, by the same
mechanism of creating a new dispatcher and swapping it out atomically.