### PR TITLE
Add xdp_clean_references

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -41,6 +41,7 @@ struct xdp_multiprog;
 
 long libxdp_get_error(const void *ptr);
 int libxdp_strerror(int err, char *buf, size_t size);
+int libxdp_clean_references(int ifindex);
 
 
 struct xdp_program *xdp_program__from_bpf_obj(struct bpf_object *obj,

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -38,5 +38,6 @@ LIBXDP_1.0.0 {
 		xdp_program__tag;
 };
 
-LIBXDP_1.1.0 {
+LIBXDP_1.2.0 {
+		libxdp_clean_references;
 } LIBXDP_1.0.0;

--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -25,6 +25,7 @@ Where COMMAND can be one of:
        load        - load an XDP program on an interface
        unload      - unload an XDP program from an interface
        status      - show current XDP program status
+       clean       - clean up detached program links in XDP bpffs directory
        help        - show the list of available commands
 #+end_src
 
@@ -114,6 +115,27 @@ Enable debug logging. Specify twice for even more verbosity.
 ** -h, --help
 Display a summary of the available options
 
+* The CLEAN command
+
+The syntax for the =clean= command is:
+
+=xdp-loader clean [options] [ifname]=
+
+The =clean= command cleans up any detached program links in the XDP bpffs
+directory.  When a network interface disappears, any programs loaded in software
+mode (e.g. skb, native) remain pinned in the bpffs directory, but become
+detached from the interface. These need to be unlinked from the filesystem. The
+=clean= command takes an optional interface parameter to only unlink detached
+programs corresponding to the interface.  By default, all detached programs for
+all interfaces are unlinked.
+
+The supported options are:
+
+** -v, --verbose
+Enable debug logging. Specify twice for even more verbosity.
+
+** -h, --help
+Display a summary of the available options
 
 * Examples
 

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -285,6 +285,26 @@ int do_status(const void *cfg, __unused const char *pin_root_path)
 	return iface_print_status(opt->iface.ifindex ? &opt->iface : NULL);
 }
 
+static const struct cleanopt {
+	struct iface iface;
+} defaults_clean = {};
+
+static struct prog_option clean_options[] = {
+	DEFINE_OPTION("dev", OPT_IFNAME, struct cleanopt, iface,
+		      .positional = true, .metavar = "[ifname]",
+		      .help = "Clean up detached program links for [ifname] (default all interfaces)"),
+	END_OPTIONS
+};
+
+int do_clean(const void *cfg, __unused const char *pin_root_path)
+{
+	const struct cleanopt *opt = cfg;
+
+	printf("Cleaning up detached XDP program links for %s\n", opt->iface.ifindex ?
+	       opt->iface.ifname : "all interfaces");
+	return libxdp_clean_references(opt->iface.ifindex);
+}
+
 int do_help(__unused const void *cfg, __unused const char *pin_root_path)
 {
 	fprintf(stderr,
@@ -294,6 +314,7 @@ int do_help(__unused const void *cfg, __unused const char *pin_root_path)
 		"       load        - load an XDP program on an interface\n"
 		"       unload      - unload an XDP program from an interface\n"
 		"       status      - show current XDP program status\n"
+		"       clean       - clean up detached program links in XDP bpffs directory\n"
 		"       help        - show this help message\n"
 		"\n"
 		"Use 'xdp-loader COMMAND --help' to see options for each command\n");
@@ -303,6 +324,7 @@ int do_help(__unused const void *cfg, __unused const char *pin_root_path)
 static const struct prog_command cmds[] = {
 	DEFINE_COMMAND(load, "Load an XDP program on an interface"),
 	DEFINE_COMMAND(unload, "Unload an XDP program from an interface"),
+	DEFINE_COMMAND(clean, "Clean up detached program links in XDP bpffs directory"),
 	DEFINE_COMMAND(status, "Show XDP program status"),
 	{ .name = "help", .func = do_help, .no_cfg = true },
 	END_COMMANDS


### PR DESCRIPTION
This PR implements a clean up function to check if a ifindex's dispatcher directory is stale, and removes the pinned directory. Optionally, passing ifindex 0 makes the helper walk the entire XDP bpffs directory, looking for stale entries.

This is now exposed to the user through the `xdp-loader collect [ifname]` command.