### PR TITLE
Check compatibility for pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,11 @@ jobs:
         - KERNEL_VERSION=5.11.0
         - KERNEL_PATCH_VERSION=156.fc34
       <<: *selftest_template
+    - name: Selftests using 5.6.19 kernel
+      env:
+        - KERNEL_VERSION=5.6.19
+        - KERNEL_PATCH_VERSION=300.fc32
+      <<: *selftest_template
 
 env:
   global:

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1924,7 +1924,10 @@ struct xdp_multiprog *xdp_multiprog__get_from_ifindex(int ifindex)
 static int xdp_multiprog__check_compat(struct xdp_multiprog *mp)
 {
 	struct xdp_program *test_prog;
-	int err, lfd;
+	const char *bpffs_dir;
+	char buf[PATH_MAX];
+	int lock_fd;
+	int err;
 
 	if (mp->checked_compat)
 		return 0;
@@ -1939,7 +1942,7 @@ static int xdp_multiprog__check_compat(struct xdp_multiprog *mp)
 
 	err = bpf_program__set_attach_target(test_prog->bpf_prog,
 					     mp->main_prog->prog_fd,
-					     "prog0");
+					     "compat_test");
 	if (err) {
 		pr_debug("Failed to set attach target: %s\n", strerror(-err));
 		goto out;
@@ -1956,15 +1959,46 @@ static int xdp_multiprog__check_compat(struct xdp_multiprog *mp)
 		goto out;
 	}
 
-	lfd = bpf_raw_tracepoint_open(NULL, test_prog->prog_fd);
-	if (lfd < 0) {
+	test_prog->link_fd = bpf_raw_tracepoint_open(NULL, test_prog->prog_fd);
+	if (test_prog->link_fd < 0) {
 		err = -errno;
 		pr_debug("Failed to attach test program to dispatcher: %s\n",
 			 strerror(-err));
 		goto out;
 	}
-	close(lfd);
+
+	bpffs_dir = get_bpffs_dir();
+	if (IS_ERR(bpffs_dir)) {
+		err = PTR_ERR(bpffs_dir);
+		goto out;
+	}
+
+	err = try_snprintf(buf, sizeof(buf), "%s/prog-test-link-%i-%i",
+			   bpffs_dir, mp->ifindex, test_prog->prog_id);
+	if (err)
+		goto out;
+
+	lock_fd = xdp_lock_acquire();
+	if (lock_fd < 0) {
+		err = lock_fd;
+		goto out;
+	}
+
+	err = bpf_obj_pin(test_prog->link_fd, buf);
+	if (err) {
+		pr_warn("Couldn't pin link FD at %s: %s\n", buf, strerror(-err));
+		goto out_locked;
+	}
+	err = unlink(buf);
+	if (err) {
+		err = -errno;
+		pr_warn("Couldn't unlink file %s: %s\n", buf, strerror(-err));
+		goto out_locked;
+	}
+
 	mp->checked_compat = true;
+out_locked:
+	xdp_lock_release(lock_fd);
 out:
 	xdp_program__close(test_prog);
 

--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -40,6 +40,16 @@ int format(`prog%d', i)(struct xdp_md *ctx) {
 }
 ')
 
+__attribute__ ((noinline))
+int compat_test(struct xdp_md *ctx) {
+        volatile int ret = XDP_DISPATCHER_RETVAL;
+
+        if (!ctx)
+          return XDP_ABORTED;
+        return ret;
+}
+
+
 SEC("xdp/dispatcher")
 int xdp_dispatcher(struct xdp_md *ctx)
 {
@@ -53,6 +63,12 @@ forloop(`i', `0', NUM_PROGS,
         if (!((1U << ret) & conf.chain_call_actions[i]))
                 return ret;
 ')
+        /* keep a reference to the compat_test() function so we can use it
+         * as an freplace target in xdp_multiprog__check_compat() in libxdp
+         */
+        if (num_progs_enabled < incr(NUM_PROGS))
+                goto out;
+        ret = compat_test(ctx);
 out:
         return XDP_PASS;
 }

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -107,6 +107,7 @@ test_capt_pcap()
 
     PID=$(start_background "$XDPDUMP -i $NS --use-pcap -w - 2> /dev/null | tcpdump -r - -n")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
+    sleep 1
     RESULT=$(stop_background "$PID")
 
     $XDP_LOADER unload "$NS" --all || return 1

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -454,6 +454,7 @@ static struct prog_option unload_options[] = {
 int do_unload(const void *cfg, const char *pin_root_path)
 {
 	const struct unloadopt *opt = cfg;
+	enum xdp_attach_mode mode;
 	struct xdp_program *prog;
 	int err = EXIT_SUCCESS;
 	char buf[100];
@@ -477,14 +478,14 @@ int do_unload(const void *cfg, const char *pin_root_path)
 		goto out;
 	}
 
-	err = get_pinned_program(&opt->iface, pin_root_path, NULL, &prog);
+	err = get_pinned_program(&opt->iface, pin_root_path, &mode, &prog);
 	if (err) {
 		pr_warn("xdp-filter is not loaded on %s\n", opt->iface.ifname);
 		err = EXIT_FAILURE;
 		goto out;
 	}
 
-	err = remove_iface_program(&opt->iface, prog, XDP_MODE_UNSPEC,
+	err = remove_iface_program(&opt->iface, prog, mode,
 				   (void *)pin_root_path);
 	if (err)
 		goto out;

--- a/xdp-loader/tests/test-xdp-loader.sh
+++ b/xdp-loader/tests/test-xdp-loader.sh
@@ -28,6 +28,8 @@ check_progs_loaded()
 
 test_load_multi()
 {
+    skip_if_legacy_fallback
+
     check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o $TEST_PROG_DIR/xdp_pass.o -vv
     check_progs_loaded $NS 2
     check_run $XDP_LOADER unload $NS --all -vv
@@ -35,6 +37,8 @@ test_load_multi()
 
 test_load_incremental()
 {
+    skip_if_legacy_fallback
+
     local output
     local ret
     local id
@@ -43,7 +47,7 @@ test_load_incremental()
 
     check_progs_loaded $NS 1
 
-    output=$($XDP_LOADER load $NS $TEST_PROG_DIR/xdp_pass.o -vv)
+    output=$($XDP_LOADER load $NS $TEST_PROG_DIR/xdp_pass.o -vv 2>&1)
     ret=$?
 
     if [ "$ret" -ne "0" ] && echo $output | grep -q "Falling back to loading single prog"; then


### PR DESCRIPTION
Older kernels do not support pinning of programs. Check if current kernel does and if it does not then use legacy program.
There is a problem with the fact that unlinking of the pin is non-blocking and therefore the test program might be still pinned while the real program is being linked. I tried to solve this by adding a timeout, but I am not sure if there is some more elegant solution.
I also set some tests to be skipped depending on the kernel version. This means two tests of xdp-loader for loading multiple programs and almost every test of xdpdump, since it cannot dump if there is legacy program already attached on the interface.