### PR TITLE
Freplace dispatcher if there is only one program attached

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -100,5 +100,6 @@ enum xdp_attach_mode xdp_multiprog__attach_mode(const struct xdp_multiprog *mp);
 struct xdp_program *xdp_multiprog__main_prog(const struct xdp_multiprog *mp);
 struct xdp_program *xdp_multiprog__hw_prog(const struct xdp_multiprog *mp);
 bool xdp_multiprog__is_legacy(const struct xdp_multiprog *mp);
+int xdp_multiprog__program_count(const struct xdp_multiprog *mp);
 
 #endif

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -2614,6 +2614,14 @@ bool xdp_multiprog__is_legacy(const struct xdp_multiprog *mp)
 	return !!(mp && mp->is_legacy);
 }
 
+int xdp_multiprog__program_count(const struct xdp_multiprog *mp)
+{
+	if (!mp)
+		return -EINVAL;
+
+	return mp->num_links;
+}
+
 static __u32 xdp_get_ifindex_prog_id(int ifindex)
 {
 	struct xdp_link_info xinfo = {};

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -2062,6 +2062,7 @@ static int xdp_multiprog__link_prog(struct xdp_multiprog *mp,
 	bool was_loaded = false;
 	char buf[PATH_MAX];
 	int err, lfd = -1;
+	char *attach_func;
 	__s32 btf_id;
 
 	if (!mp || !prog || !mp->is_loaded ||
@@ -2085,17 +2086,23 @@ static int xdp_multiprog__link_prog(struct xdp_multiprog *mp,
 	if (err)
 		goto err;
 
-	btf_id = find_prog_btf_id(buf, mp->main_prog->prog_fd);
+
+	if (mp->config.num_progs_enabled == 1)
+		attach_func = "xdp_dispatcher";
+	else
+		attach_func = buf;
+
+	btf_id = find_prog_btf_id(attach_func, mp->main_prog->prog_fd);
 	if (btf_id <= 0) {
 		err = btf_id;
-		pr_debug("Couldn't find BTF ID for %s: %d\n", buf, err);
+		pr_debug("Couldn't find BTF ID for %s: %d\n", attach_func, err);
 		goto err;
 	}
 
 	if (prog->prog_fd < 0) {
 		err = bpf_program__set_attach_target(prog->bpf_prog,
 						     mp->main_prog->prog_fd,
-						     buf);
+						     attach_func);
 		if (err) {
 			pr_debug("Failed to set attach target: %s\n", strerror(-err));
 			goto err;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -40,4 +40,5 @@ LIBXDP_1.0.0 {
 
 LIBXDP_1.2.0 {
 		libxdp_clean_references;
+		xdp_multiprog__program_count;
 } LIBXDP_1.0.0;

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -951,6 +951,13 @@ static int find_target(struct dumpopt *cfg, struct xdp_multiprog *mp,
 
 	/* First take care of the default case, i.e. no function supplied */
 	if (!program_names) {
+		/* The libxdp code optimization where it skips the dispatcher
+		 * if only one program is loaded. If this is the case, we need
+		 * to attach to the actual first program, not the dispatcher.
+		 */
+		if (xdp_multiprog__program_count(mp) == 1)
+			prog = xdp_multiprog__next_prog(NULL, mp);
+
 		matches = find_func_matches(xdp_program__btf(prog),
 					    xdp_program__name(prog),
 					    &func, false, -1, false);
@@ -970,7 +977,6 @@ static int find_target(struct dumpopt *cfg, struct xdp_multiprog *mp,
 		pr_warn("ERROR: Can't identify the full XDP main function!\n"
 			"The following is a list of candidates:\n");
 
-		prog = xdp_multiprog__main_prog(mp);
 		find_func_matches(xdp_program__btf(prog),
 				  xdp_program__name(prog),
 				  &func, true, -1, false);


### PR DESCRIPTION
One commit introduces this. Since the default behaviour is changed (causing e.g. xdpdump to not be able to be attached), the other commit disables it by default. This might fix issue #103, but while testing I did not see any noticeable difference in performance even between single legacy program and a program with non-freplaced dispatcher, but that might be just a bad testing setup.