### PR TITLE
Unbreak selftests

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-make test >> TEST_OUTPUT 2>&1
+make test V=1 >> TEST_OUTPUT 2>&1
 echo $? > TEST_RESULT

--- a/configure
+++ b/configure
@@ -193,6 +193,7 @@ check_libbpf()
         cat >$TMPDIR/libbpftest.c <<EOF
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
+#include <bpf/btf.h>
 int main(int argc, char **argv) {
     void *ptr;
     DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts, .pin_root_path = "/path");
@@ -201,12 +202,12 @@ int main(int argc, char **argv) {
     (void) bpf_object__open_file("file", &opts);
     (void) bpf_program__name(ptr);
     (void) bpf_map__set_initial_value(ptr, ptr, 0);
-    (void) bpf_set_link_xdp_fd_opts(0, 0, 0, &lopts);
+    (void) bpf_set_link_xdp_fd_opts(0, 0, 0, &xlopts);
     return 0;
 }
 EOF
 
-        libbpf_err=$($CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c  $LIBBPF_CFLAGS -lbpf 2>&1)
+        libbpf_err=$($CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c -Werror $LIBBPF_CFLAGS -lbpf 2>&1)
         if [ "$?" -eq "0" ]; then
             echo "SYSTEM_LIBBPF:=y" >>$CONFIG
             echo "LIBBPF_VERSION=$LIBBPF_VERSION" >>$CONFIG

--- a/configure
+++ b/configure
@@ -238,6 +238,10 @@ EOF
         OBJECT_LIBBPF=
         echo "custom v$LIBBPF_VERSION"
     else
+        if ! [ -d "lib/libbpf/src" ] && [ -f ".gitmodules" ] && [ -e ".git" ]; then
+            git submodule init && git submodule update
+        fi
+
         LIBBPF_VERSION=$(get_libbpf_version "lib/libbpf/src")
         LIBBPF_INCLUDE_DIR='$(LIB_DIR)/libbpf/src/root/usr/include'
         LIBBPF_LIB_DIR='$(LIB_DIR)/libbpf/src'
@@ -252,9 +256,6 @@ EOF
     echo "LDFLAGS += -L${LIBBPF_LIB_DIR}" >>$CONFIG
     echo 'LDLIBS += -l:libbpf.a' >>$CONFIG
     echo "OBJECT_LIBBPF = ${OBJECT_LIBBPF}" >>$CONFIG
-    if ! [ -d "lib/libbpf/src" ] && [ -f ".gitmodules" ] && [ -e ".git" ]; then
-        git submodule init && git submodule update
-    fi
 
     echo -n "ELF support: "
     check_elf || exit 1

--- a/headers/linux/bpf.h
+++ b/headers/linux/bpf.h
@@ -1225,8 +1225,6 @@ enum {
 
 /* If set, run the test on the cpu specified by bpf_attr.test.cpu */
 #define BPF_F_TEST_RUN_ON_CPU	(1U << 0)
-/* If set, XDP frames will be transmitted after processing */
-#define BPF_F_TEST_XDP_LIVE_FRAMES	(1U << 1)
 
 /* type for BPF_ENABLE_STATS */
 enum bpf_stats_type {
@@ -1344,10 +1342,8 @@ union bpf_attr {
 			/* or valid module BTF object fd or 0 to attach to vmlinux */
 			__u32		attach_btf_obj_fd;
 		};
-		__u32		core_relo_cnt;	/* number of bpf_core_relo */
+		__u32		:32;		/* pad */
 		__aligned_u64	fd_array;	/* array of FDs */
-		__aligned_u64	core_relos;
-		__u32		core_relo_rec_size; /* sizeof(struct bpf_core_relo) */
 	};
 
 	struct { /* anonymous struct used by BPF_OBJ_* commands */
@@ -1748,7 +1744,7 @@ union bpf_attr {
  * 		if the maximum number of tail calls has been reached for this
  * 		chain of programs. This limit is defined in the kernel by the
  * 		macro **MAX_TAIL_CALL_CNT** (not accessible to user space),
- *		which is currently set to 33.
+ * 		which is currently set to 32.
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
@@ -4942,84 +4938,6 @@ union bpf_attr {
  *		**-ENOENT** if symbol is not found.
  *
  *		**-EPERM** if caller does not have permission to obtain kernel address.
- *
- * long bpf_find_vma(struct task_struct *task, u64 addr, void *callback_fn, void *callback_ctx, u64 flags)
- *	Description
- *		Find vma of *task* that contains *addr*, call *callback_fn*
- *		function with *task*, *vma*, and *callback_ctx*.
- *		The *callback_fn* should be a static function and
- *		the *callback_ctx* should be a pointer to the stack.
- *		The *flags* is used to control certain aspects of the helper.
- *		Currently, the *flags* must be 0.
- *
- *		The expected callback signature is
- *
- *		long (\*callback_fn)(struct task_struct \*task, struct vm_area_struct \*vma, void \*callback_ctx);
- *
- *	Return
- *		0 on success.
- *		**-ENOENT** if *task->mm* is NULL, or no vma contains *addr*.
- *		**-EBUSY** if failed to try lock mmap_lock.
- *		**-EINVAL** for invalid **flags**.
- *
- * long bpf_loop(u32 nr_loops, void *callback_fn, void *callback_ctx, u64 flags)
- *	Description
- *		For **nr_loops**, call **callback_fn** function
- *		with **callback_ctx** as the context parameter.
- *		The **callback_fn** should be a static function and
- *		the **callback_ctx** should be a pointer to the stack.
- *		The **flags** is used to control certain aspects of the helper.
- *		Currently, the **flags** must be 0. Currently, nr_loops is
- *		limited to 1 << 23 (~8 million) loops.
- *
- *		long (\*callback_fn)(u32 index, void \*ctx);
- *
- *		where **index** is the current index in the loop. The index
- *		is zero-indexed.
- *
- *		If **callback_fn** returns 0, the helper will continue to the next
- *		loop. If return value is 1, the helper will skip the rest of
- *		the loops and return. Other return values are not used now,
- *		and will be rejected by the verifier.
- *
- *	Return
- *		The number of loops performed, **-EINVAL** for invalid **flags**,
- *		**-E2BIG** if **nr_loops** exceeds the maximum number of loops.
- *
- * long bpf_strncmp(const char *s1, u32 s1_sz, const char *s2)
- *	Description
- *		Do strncmp() between **s1** and **s2**. **s1** doesn't need
- *		to be null-terminated and **s1_sz** is the maximum storage
- *		size of **s1**. **s2** must be a read-only string.
- *	Return
- *		An integer less than, equal to, or greater than zero
- *		if the first **s1_sz** bytes of **s1** is found to be
- *		less than, to match, or be greater than **s2**.
- *
- * long bpf_get_func_arg(void *ctx, u32 n, u64 *value)
- *	Description
- *		Get **n**-th argument (zero based) of the traced function (for tracing programs)
- *		returned in **value**.
- *
- *	Return
- *		0 on success.
- *		**-EINVAL** if n >= arguments count of traced function.
- *
- * long bpf_get_func_ret(void *ctx, u64 *value)
- *	Description
- *		Get return value of the traced function (for tracing programs)
- *		in **value**.
- *
- *	Return
- *		0 on success.
- *		**-EOPNOTSUPP** for tracing programs other than BPF_TRACE_FEXIT or BPF_MODIFY_RETURN.
- *
- * long bpf_get_func_arg_cnt(void *ctx)
- *	Description
- *		Get number of arguments of the traced function (for tracing programs).
- *
- *	Return
- *		The number of arguments of the traced function.
  */
 #define __BPF_FUNC_MAPPER(FN)		\
 	FN(unspec),			\
@@ -5202,12 +5120,6 @@ union bpf_attr {
 	FN(trace_vprintk),		\
 	FN(skc_to_unix_sock),		\
 	FN(kallsyms_lookup_name),	\
-	FN(find_vma),			\
-	FN(loop),			\
-	FN(strncmp),			\
-	FN(get_func_arg),		\
-	FN(get_func_ret),		\
-	FN(get_func_arg_cnt),		\
 	/* */
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper
@@ -6384,7 +6296,6 @@ struct bpf_sk_lookup {
 	__u32 local_ip4;	/* Network byte order */
 	__u32 local_ip6[4];	/* Network byte order */
 	__u32 local_port;	/* Host byte order */
-	__u32 ingress_ifindex;		/* The arriving interface. Determined by inet_iif. */
 };
 
 /*
@@ -6415,80 +6326,6 @@ enum {
 	BTF_F_NONAME	=	(1ULL << 1),
 	BTF_F_PTR_RAW	=	(1ULL << 2),
 	BTF_F_ZERO	=	(1ULL << 3),
-};
-
-/* bpf_core_relo_kind encodes which aspect of captured field/type/enum value
- * has to be adjusted by relocations. It is emitted by llvm and passed to
- * libbpf and later to the kernel.
- */
-enum bpf_core_relo_kind {
-	BPF_CORE_FIELD_BYTE_OFFSET = 0,      /* field byte offset */
-	BPF_CORE_FIELD_BYTE_SIZE = 1,        /* field size in bytes */
-	BPF_CORE_FIELD_EXISTS = 2,           /* field existence in target kernel */
-	BPF_CORE_FIELD_SIGNED = 3,           /* field signedness (0 - unsigned, 1 - signed) */
-	BPF_CORE_FIELD_LSHIFT_U64 = 4,       /* bitfield-specific left bitshift */
-	BPF_CORE_FIELD_RSHIFT_U64 = 5,       /* bitfield-specific right bitshift */
-	BPF_CORE_TYPE_ID_LOCAL = 6,          /* type ID in local BPF object */
-	BPF_CORE_TYPE_ID_TARGET = 7,         /* type ID in target kernel */
-	BPF_CORE_TYPE_EXISTS = 8,            /* type existence in target kernel */
-	BPF_CORE_TYPE_SIZE = 9,              /* type size in bytes */
-	BPF_CORE_ENUMVAL_EXISTS = 10,        /* enum value existence in target kernel */
-	BPF_CORE_ENUMVAL_VALUE = 11,         /* enum value integer value */
-};
-
-/*
- * "struct bpf_core_relo" is used to pass relocation data form LLVM to libbpf
- * and from libbpf to the kernel.
- *
- * CO-RE relocation captures the following data:
- * - insn_off - instruction offset (in bytes) within a BPF program that needs
- *   its insn->imm field to be relocated with actual field info;
- * - type_id - BTF type ID of the "root" (containing) entity of a relocatable
- *   type or field;
- * - access_str_off - offset into corresponding .BTF string section. String
- *   interpretation depends on specific relocation kind:
- *     - for field-based relocations, string encodes an accessed field using
- *       a sequence of field and array indices, separated by colon (:). It's
- *       conceptually very close to LLVM's getelementptr ([0]) instruction's
- *       arguments for identifying offset to a field.
- *     - for type-based relocations, strings is expected to be just "0";
- *     - for enum value-based relocations, string contains an index of enum
- *       value within its enum type;
- * - kind - one of enum bpf_core_relo_kind;
- *
- * Example:
- *   struct sample {
- *       int a;
- *       struct {
- *           int b[10];
- *       };
- *   };
- *
- *   struct sample *s = ...;
- *   int *x = &s->a;     // encoded as "0:0" (a is field #0)
- *   int *y = &s->b[5];  // encoded as "0:1:0:5" (anon struct is field #1,
- *                       // b is field #0 inside anon struct, accessing elem #5)
- *   int *z = &s[10]->b; // encoded as "10:1" (ptr is used as an array)
- *
- * type_id for all relocs in this example will capture BTF type id of
- * `struct sample`.
- *
- * Such relocation is emitted when using __builtin_preserve_access_index()
- * Clang built-in, passing expression that captures field address, e.g.:
- *
- * bpf_probe_read(&dst, sizeof(dst),
- *		  __builtin_preserve_access_index(&src->a.b.c));
- *
- * In this case Clang will emit field relocation recording necessary data to
- * be able to find offset of embedded `a.b.c` field within `src` struct.
- *
- * [0] https://llvm.org/docs/LangRef.html#getelementptr-instruction
- */
-struct bpf_core_relo {
-	__u32 insn_off;
-	__u32 type_id;
-	__u32 access_str_off;
-	enum bpf_core_relo_kind kind;
 };
 
 #endif /* _UAPI__LINUX_BPF_H__ */

--- a/headers/linux/btf.h
+++ b/headers/linux/btf.h
@@ -43,7 +43,7 @@ struct btf_type {
 	 * "size" tells the size of the type it is describing.
 	 *
 	 * "type" is used by PTR, TYPEDEF, VOLATILE, CONST, RESTRICT,
-	 * FUNC, FUNC_PROTO, VAR, DECL_TAG and TYPE_TAG.
+	 * FUNC, FUNC_PROTO, VAR and DECL_TAG.
 	 * "type" is a type_id referring to another type.
 	 */
 	union {
@@ -75,7 +75,6 @@ enum {
 	BTF_KIND_DATASEC	= 15,	/* Section	*/
 	BTF_KIND_FLOAT		= 16,	/* Floating point	*/
 	BTF_KIND_DECL_TAG	= 17,	/* Decl Tag */
-	BTF_KIND_TYPE_TAG	= 18,	/* Type Tag */
 
 	NR_BTF_KINDS,
 	BTF_KIND_MAX		= NR_BTF_KINDS - 1,

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -483,13 +483,16 @@ test_pname_parse()
     local PROG_ID_2=0
     local PROG_ID_3=0
     local PROG_ID_4=0
+    local BPFTOOL_ARGS=
 
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
 
+    bpftool help 2>&1 | grep -q -- '--legacy' && BPFTOOL_ARGS="--legacy"
+
     # Here we load the programs without the xdp-tools loader to make sure
     # they are not loaded as a multi-program.
-    bpftool prog loadall "$TEST_PROG_DIR/test_long_func_name.o" "$PIN_DIR"
-    bpftool net attach xdpgeneric pinned "$PIN_DIR/xdp_test_prog_long" dev "$NS"
+    bpftool $BPFTOOL_ARGS prog loadall "$TEST_PROG_DIR/test_long_func_name.o" "$PIN_DIR"
+    bpftool $BPFTOOL_ARGS net attach xdpgeneric pinned "$PIN_DIR/xdp_test_prog_long" dev "$NS"
 
     # We need to specify the function name or else it should fail
     PID=$(start_background "$XDPDUMP -i $NS")

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -916,8 +916,8 @@ int print_iface_status(const struct iface *iface, struct xdp_program *prog,
 int do_status(__unused const void *cfg, const char *pin_root_path)
 {
 	int err = EXIT_SUCCESS, map_fd = -1;
+	struct bpf_map_info info = {};
 	struct stats_record rec = {};
-	struct bpf_map_info info;
 
 	map_fd = get_pinned_map_fd(pin_root_path, textify(XDP_STATS_MAP_NAME), &info);
 	if (map_fd < 0) {


### PR DESCRIPTION
It turns out that there actually *was* a real bug in xdp-filter which was the cause of the test breakage. However, because the bug was due to uninitialised memory being passed to the kernel, it only triggered occasionally and so it has apparently slipped by for quite some time.

While investigating the breakage, a couple of other errors surfaces, so fix all of them which should hopefully bring the tests back in good shape.