### PR TITLE
A few fixes to the man page generation

### DIFF
--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -152,8 +152,10 @@ $(MAN_OBJ): README.org $(LIBMK)
 	$(Q)$(EMACS) -Q --batch --find-file $< --eval "(progn (require 'ox-man)(org-man-export-to-man))"
 	$(Q)touch -r $< $@
 
-$(MAN_PAGE): $(MAN_OBJ)
-	$(QUIET_GEN)sed -e "1 s/DATE/$(shell date '+%B %_d, %Y')/" -e "1 s/VERSION/v$(TOOLS_VERSION)/" $< > $@
+$(MAN_PAGE): $(MAN_OBJ) $(LIBMK)
+	$(QUIET_GEN)MODDATE=$$(git log -1 --pretty="format:%cI" README.org 2>/dev/null); \
+		[ "$$?" -eq "0" ] && DATE=$$(date '+%B %_d, %Y' -d "$$MODDATE") || DATE=$$(date '+%B %_d, %Y'); \
+		sed -e "1 s/DATE/$$DATE/" -e "1 s/VERSION/v$(TOOLS_VERSION)/" $< > $@
 
 endif
 

--- a/lib/libxdp/libxdp.3
+++ b/lib/libxdp/libxdp.3
@@ -1,4 +1,4 @@
-.TH "libxdp" "3" "January  5, 2022" "v1.2.0" "libxdp - library for loading XDP programs" 
+.TH "libxdp" "3" "January 12, 2022" "v1.2.0" "libxdp - library for loading XDP programs" 
 
 .SH "libxdp - library for attaching XDP programs and using AF_XDP sockets"
 .PP
@@ -469,10 +469,13 @@ attached to each interface.
 
 .PP
 To load AF_XDP programs, kernel support for AF_XDP sockets needs to be included
-and enabled in the kernel build. This was introduced in a series of commits that
-first appeared in the upstream kernel version 4.18. When using AF_XDP sockets,
-an XDP program is also loaded on the interface; for this to co-exist with other
-programs, the same constraints for multiprog applies as outlined above.
+and enabled in the kernel build. In addition, when using AF_XDP sockets, an XDP
+program is also loaded on the interface. The XDP program used for this by libxdp
+requires the ability to do map lookups into XSK maps, which was introduced with
+commit fada7fdc83c0 ("bpf: Allow bpf_map_lookup_elem() on an xskmap") in kernel
+5.3. This means that the minimum required kernel version for using AF_XDP is
+kernel 5.3; however, for the AF_XDP XDP program to co-exist with other programs,
+the same constraints for multiprog applies as outlined above.
 
 .PP
 Note that some Linux distributions backport features to earlier kernel versions,

--- a/lib/libxdp/libxdp.3
+++ b/lib/libxdp/libxdp.3
@@ -1,4 +1,4 @@
-.TH "libxdp" "3" "January 12, 2022" "v1.2.0" "libxdp - library for loading XDP programs" 
+.TH "libxdp" "3" "January 10, 2022" "v1.2.0" "libxdp - library for loading XDP programs" 
 
 .SH "libxdp - library for attaching XDP programs and using AF_XDP sockets"
 .PP

--- a/xdp-dump/xdpdump.8
+++ b/xdp-dump/xdpdump.8
@@ -1,4 +1,4 @@
-.TH "xdpdump" "8" "NOVEMBER  5, 2021" "V1.2.0" "a simple tcpdump like tool for capturing packets at the XDP layer" 
+.TH "xdpdump" "8" "JANUARY 13, 2021" "V1.2.0" "a simple tcpdump like tool for capturing packets at the XDP layer" 
 
 .SH "xdpdump - a simple tcpdump like tool for capturing packets at the XDP layer"
 .PP

--- a/xdp-filter/xdp-filter.8
+++ b/xdp-filter/xdp-filter.8
@@ -1,4 +1,4 @@
-.TH "xdp-filter" "8" "NOVEMBER  5, 2021" "V1.2.0" "A simple XDP-powered packet filter" 
+.TH "xdp-filter" "8" "JULY 10, 2020" "V1.2.0" "A simple XDP-powered packet filter" 
 
 .SH "XDP-filter - a simple XDP-powered packet filter"
 .PP

--- a/xdp-loader/xdp-loader.8
+++ b/xdp-loader/xdp-loader.8
@@ -1,4 +1,4 @@
-.TH "xdp-loader" "8" "JANUARY  3, 2022" "V1.2.0" "XDP program loader" 
+.TH "xdp-loader" "8" "JANUARY  4, 2022" "V1.2.0" "XDP program loader" 
 
 .SH "XDP-loader - an XDP program loader"
 .PP


### PR DESCRIPTION
This fixes the man page generation to use the latest modification time in git
instead of the current time when generating the man pages. This prevents builds
from marking all the man pages as modified when their content hasn't actually
changed.