### PR TITLE
testing: add test-tool to testing framework with basic load

### DIFF
--- a/.github/scripts/prepare_test_tools.sh
+++ b/.github/scripts/prepare_test_tools.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-echo ::group::Install bpftool
-git clone --depth=1 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git bpftool
-sudo make install -C bpftool/tools/bpf/bpftool/ prefix=/usr
-echo ::endgroup::
-
 
 echo ::group::Install xdp-test-harness
 sudo python3 -m pip install xdp_test_harness

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -14,6 +14,8 @@ XDP_C = ${XDP_TARGETS:=.c}
 XDP_OBJ = ${XDP_C:.c=.o}
 USER_C := ${USER_TARGETS:=.c}
 USER_OBJ := ${USER_C:.c=.o}
+TEST_C := ${TEST_TARGETS:=.c}
+TEST_OBJ := ${TEST_C:.c=.o}
 XDP_OBJ_INSTALL ?= $(XDP_OBJ)
 MAN_FILES := $(MAN_PAGE)
 
@@ -57,11 +59,11 @@ BPF_CFLAGS += -I$(HEADER_DIR) $(ARCH_INCLUDES)
 
 BPF_HEADERS := $(wildcard $(HEADER_DIR)/bpf/*.h) $(wildcard $(HEADER_DIR)/xdp/*.h)
 
-all: $(USER_TARGETS) $(XDP_OBJ) $(EXTRA_TARGETS) man
+all: $(USER_TARGETS) $(XDP_OBJ) $(EXTRA_TARGETS) $(TEST_TARGETS) man
 
 .PHONY: clean
 clean::
-	$(Q)rm -f $(USER_TARGETS) $(XDP_OBJ) $(USER_OBJ) $(USER_GEN) *.ll
+	$(Q)rm -f $(USER_TARGETS) $(XDP_OBJ) $(USER_OBJ) $(TEST_OBJ) $(USER_GEN) *.ll
 
 .PHONY: install
 install: all install_local
@@ -76,6 +78,7 @@ install: all install_local
 	$(if $(TEST_FILE),install -m 0755 -d $(DESTDIR)$(SCRIPTSDIR)/tests/$(TOOL_NAME))
 	$(if $(TEST_FILE),install -m 0644 $(TEST_FILE) $(DESTDIR)$(SCRIPTSDIR)/tests/$(TOOL_NAME))
 	$(if $(TEST_FILE_DEPS),install -m 0644 $(TEST_FILE_DEPS) $(DESTDIR)$(SCRIPTSDIR)/tests/$(TOOL_NAME))
+	$(if $(TEST_TARGETS),install -m 0755 $(TEST_TARGETS) $(DESTDIR)$(SCRIPTSDIR))
 
 .PHONY: install_local
 install_local::
@@ -96,7 +99,8 @@ LIB_H := ${LIB_OBJS:.o=.h}
 $(LIB_OBJS): %.o: %.c %.h $(LIB_H)
 	$(Q)$(MAKE) -C $(dir $@) $(notdir $@)
 
-$(USER_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OBJS) $(KERN_USER_H) $(EXTRA_DEPS) $(EXTRA_USER_DEPS)
+ALL_EXEC_TARGETS=$(USER_TARGETS) $(TEST_TARGETS)
+$(ALL_EXEC_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OBJS) $(KERN_USER_H) $(EXTRA_DEPS) $(EXTRA_USER_DEPS)
 	$(QUIET_CC)$(CC) -Wall $(CFLAGS) $(LDFLAGS) -o $@ $(LIB_OBJS) \
 	 $< $(LDLIBS)
 

--- a/lib/testing/.gitignore
+++ b/lib/testing/.gitignore
@@ -1,0 +1,1 @@
+test-tool

--- a/lib/testing/Makefile
+++ b/lib/testing/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS :=
+TEST_TARGETS := test-tool
 XDP_TARGETS := test_long_func_name xdp_drop xdp_pass
 SCRIPTS_FILES := test_runner.sh setup-netns-env.sh run_tests.sh
 XDP_OBJ_INSTALL :=

--- a/lib/testing/test-tool.c
+++ b/lib/testing/test-tool.c
@@ -1,0 +1,217 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <linux/err.h>
+#include <linux/if_link.h>
+
+#include "params.h"
+#include "logging.h"
+#include "util.h"
+
+
+#define PROG_NAME "test-tool"
+
+
+#ifndef HAVE_LIBBPF_BPF_OBJECT__NEXT_PROGRAM
+static struct bpf_program *bpf_object__next_program(const struct bpf_object *obj,
+  						    struct bpf_program *prog)
+{
+  	return bpf_program__next(prog, obj);
+}
+#endif
+
+
+struct enum_val xdp_modes[] = {
+       {"native", XDP_MODE_NATIVE},
+       {"skb", XDP_MODE_SKB},
+       {"hw", XDP_MODE_HW},
+       {"unspecified", XDP_MODE_UNSPEC},
+       {NULL, 0}
+};
+
+
+static const struct loadopt {
+	bool help;
+	enum xdp_attach_mode mode;
+	struct iface iface;
+	char *filename;
+} defaults_load = {
+	.mode = XDP_MODE_NATIVE
+};
+
+
+static struct bpf_object *open_bpf_obj(const char *filename,
+				       struct bpf_object_open_opts *opts)
+{
+	struct bpf_object *obj;
+	int err;
+
+	obj = bpf_object__open_file(filename, opts);
+	err = libbpf_get_error(obj);
+	if (err) {
+		if (err == -ENOENT)
+			pr_debug(
+				"Couldn't load the eBPF program (libbpf said 'no such file').\n"
+				"Maybe the program was compiled with a too old "
+				"version of LLVM (need v9.0+)?\n");
+		return ERR_PTR(err);
+	}
+
+	return obj;
+}
+
+
+int do_load(const void *cfg, __unused const char *pin_root_path)
+{
+	const struct loadopt *opt = cfg;
+	struct bpf_program *bpf_prog;
+	char errmsg[STRERR_BUFSIZE];
+  	struct bpf_object *obj;
+	int err = EXIT_SUCCESS;
+	int xdp_flags;
+	int prog_fd;
+
+	silence_libbpf_logging();
+retry:
+	obj = open_bpf_obj(opt->filename, NULL);
+
+	if (IS_ERR(obj)) {
+		err = PTR_ERR(obj);
+
+		if (err == -EPERM && !double_rlimit())
+			goto retry;
+
+		libxdp_strerror(err, errmsg, sizeof(errmsg));
+		pr_warn("ERROR: Couldn't open file '%s': %s\n",
+			opt->filename, errmsg);
+		goto out;
+	}
+
+	err = bpf_object__load(obj);
+  	if (err) {
+
+		if (err == -EPERM && !double_rlimit()) {
+			bpf_object__close(obj);
+			goto retry;
+		}
+
+		libbpf_strerror(err, errmsg, sizeof(errmsg));
+  		pr_warn("ERROR: Can't load eBPF object: %s(%d)\n",
+			errmsg, err);
+		goto out;
+	}
+
+	bpf_prog = bpf_object__next_program(obj, NULL);
+	if (!bpf_prog) {
+  		pr_warn("ERROR: Couldn't find xdp program in bpf object!\n");
+		err = -ENOENT;
+		goto out;
+  	}
+
+	prog_fd = bpf_program__fd(bpf_prog);
+	if (prog_fd < 0) {
+		err = prog_fd;
+		libxdp_strerror(err, errmsg, sizeof(errmsg));
+  		pr_warn("ERROR: Couldn't find xdp program's file descriptor: %s\n",
+			errmsg);
+		goto out;
+  	}
+
+	xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST;
+	switch (opt->mode) {
+  	case XDP_MODE_SKB:
+  		xdp_flags |= XDP_FLAGS_SKB_MODE;
+  		break;
+  	case XDP_MODE_NATIVE:
+  		xdp_flags |= XDP_FLAGS_DRV_MODE;
+  		break;
+  	case XDP_MODE_HW:
+  		xdp_flags |= XDP_FLAGS_HW_MODE;
+  		break;
+  	case XDP_MODE_UNSPEC:
+  		break;
+  	}
+	err = bpf_set_link_xdp_fd_opts(opt->iface.ifindex, prog_fd, xdp_flags,
+				       NULL);
+	if (err < 0) {
+ 		pr_info("ERROR: Failed attaching XDP program to ifindex %d: %s\n",
+			opt->iface.ifindex, strerror(-err));
+
+  		switch (-err) {
+  		case EBUSY:
+  		case EEXIST:
+  			pr_info("XDP already loaded on device.\n");
+  			break;
+  		case EOPNOTSUPP:
+  			pr_info("XDP mode not supported; try using SKB mode.\n");
+  			break;
+  		default:
+ 			break;
+  		}
+		goto out;
+  	}
+out:
+	return err;
+}
+
+
+static struct prog_option load_options[] = {
+	DEFINE_OPTION("mode", OPT_ENUM, struct loadopt, mode,
+		      .short_opt = 'm',
+		      .typearg = xdp_modes,
+		      .metavar = "<mode>",
+		      .help = "Load XDP program in <mode>; default native"),
+	DEFINE_OPTION("dev", OPT_IFNAME, struct loadopt, iface,
+		      .positional = true,
+		      .metavar = "<ifname>",
+		      .required = true,
+		      .help = "Load on device <ifname>"),
+	DEFINE_OPTION("filename", OPT_STRING, struct loadopt, filename,
+		      .positional = true,
+		      .metavar = "<filename>",
+		      .required = true,
+		      .help = "Load program from <filename>"),
+	END_OPTIONS
+};
+
+
+int do_help(__unused const void *cfg, __unused const char *pin_root_path)
+{
+	fprintf(stderr,
+		"Usage: test-tool COMMAND [options]\n"
+		"\n"
+		"COMMAND can be one of:\n"
+		"       load        - load an XDP program on an interface\n"
+		"       help        - show this help message\n"
+		"\n"
+		"Use 'test-tool COMMAND --help' to see options for each command\n");
+	return -1;
+}
+
+
+static const struct prog_command cmds[] = {
+	DEFINE_COMMAND(load, "Load an XDP program on an interface"),
+	{ .name = "help", .func = do_help, .no_cfg = true },
+	END_COMMANDS
+};
+
+
+union all_opts {
+	struct loadopt load;
+};
+
+
+int main(int argc, char **argv)
+{
+	if (argc > 1)
+		return dispatch_commands(argv[1], argc - 1, argv + 1, cmds,
+					 sizeof(union all_opts), PROG_NAME);
+	return do_help(NULL, NULL);
+}


### PR DESCRIPTION
This commit adds a test-tool compiled binary to the testing
framework. The tool allows specific "C" tool needs to be
bundled in a single binary.

The first tool needed was a simple loader to get rid of the
bpftool used by the xdp-dump self-test.

Fixes #150

Signed-off-by: Eelco Chaudron <echaudro@redhat.com>