### PR TITLE
github/workflows: Add option to recursively checkout submodules

### DIFF
--- a/.github/workflows/covscan.yml
+++ b/.github/workflows/covscan.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Prepare packages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: "Create source archive"
         run: |

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Prepare packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
@rst0git pointed out that we can get the checkout action to also checkout
the submodule instead of relying on the configure script to do that for us.
Let's add that option to all workflows.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>