### PR TITLE
libxdp: Introduce OPTS based xdp_program__create

### DIFF
--- a/.github/scripts/prepare_test_tools.sh
+++ b/.github/scripts/prepare_test_tools.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-echo ::group::Install bpftool
-git clone --depth=1 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git bpftool
-sudo make install -C bpftool/tools/bpf/bpftool/ prefix=/usr
-echo ::endgroup::
-
 
 echo ::group::Install xdp-test-harness
 sudo python3 -m pip install xdp_test_harness

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -37,6 +37,11 @@ jobs:
           echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get -qq update
           sudo apt-get -qq -y install clang-10 lld-10 llvm-10
+      - name: Install latest bpftool
+        run: |
+          git clone --depth=1 --recurse-submodules https://github.com/libbpf/bpftool bpftool
+          make LLVM_STRIP=llvm-strip-10 -C bpftool/src
+          sudo make install -C bpftool/src prefix=/usr
       - name: Compile
         run: make
       - name: Prepare test tools

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -103,4 +103,54 @@ struct xdp_program *xdp_multiprog__hw_prog(const struct xdp_multiprog *mp);
 bool xdp_multiprog__is_legacy(const struct xdp_multiprog *mp);
 int xdp_multiprog__program_count(const struct xdp_multiprog *mp);
 
+/* Only following members can be set at once:
+ *
+ * @obj, @prog_name
+ *	Create using BPF program with name @prog_name in BPF object @obj
+ *
+ *	@prog_name is optional. In absence of @prog_name, first program of BPF
+ *	object is picked.
+ *
+ * @find_filename, @prog_name, @opts
+ *	Create using BPF program with name @prog_name in BPF object located in
+ *	LIBXDP_OBJECT_PATH with filename @find_filename, using
+ *	bpf_object_open_opts @opts.
+ *
+ *	@prog_name and @opts is optional. In absence of @prog_name, first
+ *	program of BPF object is picked.
+ *
+ * @open_filename, @prog_name, @opts
+ *	Create using BPF program with name @prog_name in BPF object located at
+ *	path @open_filename, using bpf_object_open_opts @opts.
+ *
+ *	@prog_name and @opts is optional. In absence of @prog_name, first
+ *	program of BPF object is picked.
+ *
+ * @id
+ *	Load from BPF program with ID @id
+ *
+ * @fd
+ *	Load from BPF program with fd @fd
+ *
+ * When one of these combinations is set, all other members of the opts struct
+ * must be zeroed out.
+ */
+struct xdp_program_opts {
+	size_t sz;
+	struct bpf_object *obj;
+	struct bpf_object_open_opts *opts;
+	const char *prog_name;
+	const char *find_filename;
+	const char *open_filename;
+	const char *pin_path;
+	__u32 id;
+	int fd;
+	size_t :0;
+};
+#define xdp_program_opts__last_field fd
+
+#define DECLARE_LIBXDP_OPTS DECLARE_LIBBPF_OPTS
+
+struct xdp_program *xdp_program__create(struct xdp_program_opts *opts);
+
 #endif

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -2119,7 +2119,7 @@ static int xdp_multiprog__check_compat(struct xdp_multiprog *mp)
 		return 0;
 
 	pr_debug("Checking dispatcher compatibility\n");
-	test_prog = xdp_program__find_file("xdp-dispatcher.o", "xdp/pass", NULL);
+	test_prog = __xdp_program__find_file("xdp-dispatcher.o", NULL, "xdp_pass", NULL);
 	if (IS_ERR(test_prog)) {
 		err = PTR_ERR(test_prog);
 		pr_warn("Couldn't open BPF file xdp-dispatcher.o\n");
@@ -2467,8 +2467,8 @@ static struct xdp_multiprog *xdp_multiprog__generate(struct xdp_program **progs,
 	if (num_new_progs > 1)
 		qsort(new_progs, num_new_progs, sizeof(*new_progs), cmp_xdp_programs);
 
-	dispatcher = xdp_program__find_file("xdp-dispatcher.o",
-					    "xdp/dispatcher", NULL);
+	dispatcher = __xdp_program__find_file("xdp-dispatcher.o",
+					      NULL, "xdp_dispatcher", NULL);
 	if (IS_ERR(dispatcher)) {
 		err = PTR_ERR(dispatcher);
 		pr_warn("Couldn't open BPF file 'xdp-dispatcher.o'\n");

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -67,3 +67,7 @@ LIBXDP_1.2.0 {
 		xsk_umem__extract_offset;
 		xsk_umem__get_data;
 } LIBXDP_1.0.0;
+
+LIBXDP_1.3.0 {
+		xdp_program__create;
+} LIBXDP_1.2.0;

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -52,6 +52,10 @@ LIBXDP_HIDE_SYMBOL struct xdp_program *xdp_program__clone(struct xdp_program *pr
 #define offsetof(type, member) ((size_t) & ((type *)0)->member)
 #endif
 
+#ifndef offsetofend
+#define offsetofend(TYPE, FIELD) (offsetof(TYPE, FIELD) + sizeof(((TYPE *)0)->FIELD))
+#endif
+
 #ifndef container_of
 #define container_of(ptr, type, member)                            \
 	({                                                         \
@@ -61,5 +65,55 @@ LIBXDP_HIDE_SYMBOL struct xdp_program *xdp_program__clone(struct xdp_program *pr
 #endif
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+/* OPTS macros, from libbpf_internal.h */
+
+static inline bool libxdp_is_mem_zeroed(const char *p, ssize_t len)
+{
+	while (len > 0) {
+		if (*p)
+			return false;
+		p++;
+		len--;
+	}
+	return true;
+}
+
+static inline bool libxdp_validate_opts(const char *opts,
+					size_t opts_sz, size_t user_sz,
+					const char *type_name)
+{
+	if (user_sz < sizeof(size_t)) {
+		pr_warn("%s size (%zu) is too small\n", type_name, user_sz);
+		return false;
+	}
+	if (!libxdp_is_mem_zeroed(opts + opts_sz, (ssize_t)user_sz - opts_sz)) {
+		pr_warn("%s has non-zero extra bytes\n", type_name);
+		return false;
+	}
+	return true;
+}
+
+#define OPTS_VALID(opts, type)						      \
+	(!(opts) || libxdp_validate_opts((const char *)opts,		      \
+					 offsetofend(struct type,	      \
+						     type##__last_field),     \
+					 (opts)->sz, #type))
+#define OPTS_HAS(opts, field) \
+	((opts) && opts->sz >= offsetofend(typeof(*(opts)), field))
+#define OPTS_GET(opts, field, fallback_value) \
+	(OPTS_HAS(opts, field) ? (opts)->field : fallback_value)
+#define OPTS_SET(opts, field, value)		\
+	do {					\
+		if (OPTS_HAS(opts, field))	\
+			(opts)->field = value;	\
+	} while (0)
+
+#define OPTS_ZEROED(opts, last_nonzero_field)				      \
+({									      \
+	ssize_t __off = offsetofend(typeof(*(opts)), last_nonzero_field);     \
+	!(opts) || libxdp_is_mem_zeroed((const void *)opts + __off,	      \
+					(opts)->sz - __off);		      \
+})
 
 #endif /* __LIBXDP_LIBXDP_INTERNAL_H */

--- a/lib/libxdp/protocol.org
+++ b/lib/libxdp/protocol.org
@@ -64,7 +64,7 @@ int prog0(struct xdp_md *ctx) {
 }
 /* the above is repeated as prog1...prog9 */
 
-SEC("xdp/dispatcher")
+SEC("xdp")
 int xdp_dispatcher(struct xdp_md *ctx)
 {
         __u8 num_progs_enabled = conf.num_progs_enabled;

--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -50,7 +50,7 @@ int compat_test(struct xdp_md *ctx) {
 }
 
 
-SEC("xdp/dispatcher")
+SEC("xdp")
 int xdp_dispatcher(struct xdp_md *ctx)
 {
         __u8 num_progs_enabled = conf.num_progs_enabled;
@@ -73,7 +73,7 @@ out:
         return XDP_PASS;
 }
 
-SEC("xdp/pass")
+SEC("xdp")
 int xdp_pass(struct xdp_md *ctx)
 {
         return XDP_PASS;

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -354,6 +354,7 @@ int get_pinned_program(const struct iface *iface, const char *pin_root_path,
 	}
 
 	while ((de = readdir(dr)) != NULL) {
+		DECLARE_LIBXDP_OPTS(xdp_program_opts, opts, 0);
 		struct xdp_program *prog;
 
 		if (!strcmp(".", de->d_name) || !strcmp("..", de->d_name))
@@ -372,7 +373,8 @@ int get_pinned_program(const struct iface *iface, const char *pin_root_path,
 			continue;
 		}
 
-		prog = xdp_program__from_pin(pin_path);
+		opts.pin_path = pin_path;
+		prog = xdp_program__create(&opts);
 		if (IS_ERR_OR_NULL(prog) ||
 		    !(m = xdp_program__is_attached(prog, iface->ifindex))) {
 			ret = IS_ERR(prog) ? PTR_ERR(prog) : -ENOENT;

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -375,15 +375,15 @@ int get_pinned_program(const struct iface *iface, const char *pin_root_path,
 
 		opts.pin_path = pin_path;
 		prog = xdp_program__create(&opts);
-		if (IS_ERR_OR_NULL(prog) ||
+		if (libxdp_get_error(prog) ||
 		    !(m = xdp_program__is_attached(prog, iface->ifindex))) {
-			ret = IS_ERR(prog) ? PTR_ERR(prog) : -ENOENT;
+			ret = libxdp_get_error(prog) ?: -ENOENT;
 			pr_debug("Program %s no longer loaded on %s: %s\n",
 				 de->d_name, iface->ifname, strerror(-ret));
 			err = unlink(pin_path);
 			if (err)
 				ret = err;
-			if (!IS_ERR_OR_NULL(prog))
+			if (prog)
 				xdp_program__close(prog);
 		} else {
 			if (strcmp(xdp_program__name(prog), de->d_name)) {

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -1499,6 +1499,7 @@ static void detach_traces(struct capture_programs *progs)
 static bool load_xdp_trace_program(struct dumpopt *cfg,
 				   struct capture_programs *progs)
 {
+	DECLARE_LIBXDP_OPTS(xdp_program_opts, opts, 0);
 	int                         fd, rc;
 	char                        errmsg[STRERR_BUFSIZE];
 	struct xdp_program         *prog;
@@ -1513,7 +1514,10 @@ static bool load_xdp_trace_program(struct dumpopt *cfg,
 	silence_libbpf_logging();
 	silence_libxdp_logging();
 
-	prog = xdp_program__find_file("xdpdump_xdp.o", "xdpdump_xdp", NULL);
+	opts.find_filename = "xdpdump_xdp.o";
+	opts.prog_name = "xdpdump";
+
+	prog = xdp_program__create(&opts);
 	if (libxdp_get_error(prog)) {
 		int err = libxdp_get_error(prog);
 

--- a/xdp-dump/xdpdump_xdp.c
+++ b/xdp-dump/xdpdump_xdp.c
@@ -35,7 +35,7 @@ struct trace_configuration trace_cfg SEC(".data");
 /*****************************************************************************
  * XDP trace program
  *****************************************************************************/
-SEC("xdpdump_xdp")
+SEC("xdp")
 int xdpdump(struct xdp_md *xdp)
 {
 	void *data_end = (void *)(long)xdp->data_end;

--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -243,6 +243,7 @@ int do_load(const void *cfg, const char *pin_root_path)
 	char *filename;
 	DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts,
 			    .pin_root_path = pin_root_path);
+	DECLARE_LIBXDP_OPTS(xdp_program_opts, xdp_opts, 0);
 
 	if (opt->mode == XDP_MODE_HW) {
 		pr_warn("xdp-filter does not support offloading.\n");
@@ -294,7 +295,10 @@ int do_load(const void *cfg, const char *pin_root_path)
 	silence_libbpf_logging();
 
 retry:
-	p = xdp_program__find_file(filename, "xdp_filter", &opts);
+	xdp_opts.find_filename = filename;
+	xdp_opts.opts = &opts;
+	/* prog_name is NULL, so choose the first program in object */
+	p = xdp_program__create(&xdp_opts);
 	err = libxdp_get_error(p);
 	if (err) {
 		if (err == -EPERM && !double_rlimit())

--- a/xdp-filter/xdpfilt_prog.h
+++ b/xdp-filter/xdpfilt_prog.h
@@ -194,7 +194,7 @@ struct {
 	__uint(XDP_PASS, 1);
 } XDP_RUN_CONFIG(FUNCNAME);
 
-SEC("xdp_filter")
+SEC("xdp")
 int FUNCNAME(struct xdp_md *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;

--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -69,6 +69,12 @@ Specify which ELF section to load the XDP program(s) from in each file. The
 default is to use the first program in each file. If this option is set, it
 applies to all programs being loaded.
 
+** -n, --prog-name <prog_name>
+Specify which BPF program with the name to load the XDP program(s) from in each
+file. The default is to use the first program in each file. Only one of
+--section and --prog-name may be specified. If this option is set, it applies to
+all programs being loaded.
+
 ** -v, --verbose
 Enable debug logging. Specify twice for even more verbosity.
 

--- a/xdp-loader/tests/test-xdp-loader.sh
+++ b/xdp-loader/tests/test-xdp-loader.sh
@@ -1,5 +1,5 @@
 XDP_LOADER=${XDP_LOADER:-./xdp-loader}
-ALL_TESTS="test_load test_section test_load_multi test_load_incremental"
+ALL_TESTS="test_load test_section test_prog_name test_load_multi test_load_incremental"
 
 test_load()
 {
@@ -11,6 +11,12 @@ test_section()
 {
     check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o -s xdp -vv
     check_run $XDP_LOADER unload $NS --all -vv
+}
+
+test_prog_name()
+{
+	check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o -n xdp_drop -vv
+	check_run $XDP_LOADER unload $NS --all -vv
 }
 
 check_progs_loaded()

--- a/xdp-loader/xdp-loader.8
+++ b/xdp-loader/xdp-loader.8
@@ -1,4 +1,4 @@
-.TH "xdp-loader" "8" "JANUARY  4, 2022" "V1.2.2" "XDP program loader" 
+.TH "xdp-loader" "8" "FEBRUARY  7, 2022" "V1.2.2" "XDP program loader" 
 
 .SH "XDP-loader - an XDP program loader"
 .PP
@@ -73,6 +73,13 @@ the map being loaded.
 Specify which ELF section to load the XDP program(s) from in each file. The
 default is to use the first program in each file. If this option is set, it
 applies to all programs being loaded.
+
+.SS "-n, --prog-name <prog_name>"
+.PP
+Specify which BPF program with the name to load the XDP program(s) from in each
+file. The default is to use the first program in each file. Only one of
+--section and --prog-name may be specified. If this option is set, it applies to
+all programs being loaded.
 
 .SS "-v, --verbose"
 .PP

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -128,9 +128,8 @@ retry:
 						   opt->section_name, &opts);
 		}
 
-		if (IS_ERR(p)) {
-			err = PTR_ERR(p);
-
+		err = libxdp_get_error(p);
+		if (err) {
 			if (err == -EPERM && !double_rlimit())
 				goto retry;
 

--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -25,6 +25,7 @@ static const struct loadopt {
 	struct multistring filenames;
 	char *pin_path;
 	char *section_name;
+	char *prog_name;
 	enum xdp_attach_mode mode;
 } defaults_load = {
 	.mode = XDP_MODE_NATIVE
@@ -52,6 +53,10 @@ static struct prog_option load_options[] = {
 		      .metavar = "<section>",
 		      .short_opt = 's',
 		      .help = "ELF section name of program to load (default: first in file)."),
+	DEFINE_OPTION("prog-name", OPT_STRING, struct loadopt, prog_name,
+		      .metavar = "<prog_name>",
+		      .short_opt = 'n',
+		      .help = "BPF program name of program to load (default: first in file)."),
 	DEFINE_OPTION("dev", OPT_IFNAME, struct loadopt, iface,
 		      .positional = true,
 		      .metavar = "<ifname>",
@@ -74,6 +79,11 @@ int do_load(const void *cfg, __unused const char *pin_root_path)
 	size_t num_progs, i;
 	DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts,
 			    .pin_root_path = opt->pin_path);
+
+	if (opt->section_name && opt->prog_name) {
+		pr_warn("Only one of --section or --prog-name can be set\n");
+		return EXIT_FAILURE;
+	}
 
 	num_progs = opt->filenames.num_strings;
 	if (!num_progs) {
@@ -101,12 +111,22 @@ int do_load(const void *cfg, __unused const char *pin_root_path)
 
 retry:
 	for (i = 0; i < num_progs; i++) {
+		DECLARE_LIBXDP_OPTS(xdp_program_opts, xdp_opts, 0);
+
 		p = progs[i];
 		if (p)
 			xdp_program__close(p);
 
-		p = xdp_program__open_file(opt->filenames.strings[i],
-					   opt->section_name, &opts);
+		if (opt->prog_name) {
+			xdp_opts.open_filename = opt->filenames.strings[i];
+			xdp_opts.prog_name = opt->prog_name;
+			xdp_opts.opts = &opts;
+
+			p = xdp_program__create(&xdp_opts);
+		} else {
+			p = xdp_program__open_file(opt->filenames.strings[i],
+						   opt->section_name, &opts);
+		}
 
 		if (IS_ERR(p)) {
 			err = PTR_ERR(p);


### PR DESCRIPTION
Since libbpf has deprecated custom section names and recommends usage of
bpf_object__find_program_by_name instead of bpf_program_by_section_name,
provide a new unified OPTS style xdp_program__create that can perform
XDP program creation using various options.

See commits for details.

Closes: https://github.com/xdp-project/xdp-tools/issues/153

Signed-off-by: Kumar Kartikeya Dwivedi <memxor@gmail.com>