### PR TITLE
libxdp: Demote log level for fallback messages

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1433,7 +1433,7 @@ int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,
 		mp = NULL;
 		if (err == -EOPNOTSUPP) {
 			if (num_progs == 1) {
-				pr_warn("Falling back to loading single prog "
+				pr_info("Falling back to loading single prog "
 					"without dispatcher\n");
 				return xdp_program__attach_single(progs[0], ifindex, mode);
 			} else {
@@ -2121,7 +2121,7 @@ out:
 	xdp_program__close(test_prog);
 
 	if (err) {
-		pr_warn("Compatibility check for dispatcher program failed: %s\n",
+		pr_info("Compatibility check for dispatcher program failed: %s\n",
 			strerror(-err));
 		return -EOPNOTSUPP;
 	}

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -72,7 +72,7 @@ ENABLE_VLAN=0
 is_multiprog_supported()
 {
     if [[ -z "${MULTIPROG_SUPPORT:-}" ]]; then
-        RESULT=$($XDP_LOADER load "$NS" "$TEST_PROG_DIR/xdp_pass.o" 2>&1)
+        RESULT=$($XDP_LOADER load -v "$NS" "$TEST_PROG_DIR/xdp_pass.o" 2>&1)
         if [[ "$RESULT" == *"Compatibility check for dispatcher program failed"* ]]; then
             MULTIPROG_SUPPORT="false"
         else


### PR DESCRIPTION
On architectures other than x86, falling back to regular loading of XDP
programs (without the dispatcher) is normal, so let's demote the log
messages about this so it doesn't show up by default when using xdp-loader.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>