### PR TITLE
github/workflows: Add a newer kernel to the test matrix

### DIFF
--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         include:
+         - KERNEL_VERSION: 5.16.8
+           KERNEL_PATCH_VERSION: 200.fc35
          - KERNEL_VERSION: 5.11.0
            KERNEL_PATCH_VERSION: 156.fc34
          - KERNEL_VERSION: 5.6.19


### PR DESCRIPTION
The selection of kernels we test with was getting old, let's add a 5.16
kernel to the mix.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>