### PR TITLE
lib/Makefile: Make sure util is built before testing

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -9,7 +9,10 @@ SUBDIRS=util testing
 
 all: $(SUBDIRS) libxdp
 
-$(SUBDIRS): libxdp
+util: libxdp
+	@echo; echo "  $@"; $(MAKE) -C $@
+
+testing: libxdp util
 	@echo; echo "  $@"; $(MAKE) -C $@
 
 .PHONY: libxdp


### PR DESCRIPTION
There's now a binary in testing/ which links against the objects in util/,
so we need to make sure util/ is built first or linking will fail.

Fixes: 669c7b433e70 ("testing: add test-tool to testing framework with basic load")