### PR TITLE
Add extern C to libxdp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libbpf"]
 	path = lib/libbpf
 	url = https://github.com/xdp-project/libbpf/
+	ignore = untracked

--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -15,6 +15,10 @@
 #include <bpf/bpf.h>
 #include "xdp_helpers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define XDP_BPFFS_ENVVAR "LIBXDP_BPFFS"
 #define XDP_OBJECT_ENVVAR "LIBXDP_OBJECT_PATH"
 
@@ -152,5 +156,9 @@ struct xdp_program_opts {
 #define DECLARE_LIBXDP_OPTS DECLARE_LIBBPF_OPTS
 
 struct xdp_program *xdp_program__create(struct xdp_program_opts *opts);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif


### PR DESCRIPTION
Add `extern C` to allow `libxdp` header to be included in C++ code.

Also, add `ignore=untracked` attribute to `.gitmodules`.