### PR TITLE
xdp/xsk.h: Fix compilation with -std=gnu89

### DIFF
--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -21,7 +21,11 @@
 extern "C" {
 #endif
 
+#ifdef __GNUC_STDC_INLINE__
 #define XDP_ALWAYS_INLINE inline __attribute__((__always_inline__))
+#elif __GNUC_GNU_INLINE__
+#define XDP_ALWAYS_INLINE static inline __attribute__((__always_inline__))
+#endif
 
 /* Do not access these members directly. Use the functions below. */
 #define DEFINE_XSK_RING(name) \


### PR DESCRIPTION
Commit 8ed7e2696844 ("libxdp: export inline helpers as symbols in
libxdp") used C99 inline semantics to rely on inline without extern not
emitting a symbol, and extern inline declaration doing that instead. On
C89, these C99 inline semantics are not followed.

Instead of requiring users to migrate away from C89, we can still retain
compatibility by marking XDP_ALWAYS_INLINE as static inline, while
ensuring libxdp continues to expose these symbols.

Closes: #173
Fixes: 8ed7e2696844 ("libxdp: export inline helpers as symbols in libxdp")
Signed-off-by: Kumar Kartikeya Dwivedi <memxor@gmail.com>