### PR TITLE
libxdp: unmap rings when umem deleted

### DIFF
--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -448,7 +448,7 @@ static int xsk_get_max_queues(char *ifname)
 	}
 
 	if (err) {
-		/* If the device says it has no channels, 
+		/* If the device says it has no channels,
 		 * try to get rx tx from sysfs, otherwise all traffic
 		 * is sent to a single stream, so max queues = 1.
 		 */
@@ -1046,11 +1046,22 @@ int xsk_socket__create(struct xsk_socket **xsk_ptr, const char *ifname,
 
 int xsk_umem__delete(struct xsk_umem *umem)
 {
+	struct xdp_mmap_offsets off;
+	int err;
+
 	if (!umem)
 		return 0;
 
 	if (umem->refcount)
 		return -EBUSY;
+
+	err = xsk_get_mmap_offsets(umem->fd, &off);
+	if (!err && umem->fill_save && umem->comp_save) {
+		munmap(umem->fill_save->ring - off.fr.desc,
+		       off.fr.desc + umem->config.fill_size * sizeof(__u64));
+		munmap(umem->comp_save->ring - off.cr.desc,
+		       off.cr.desc + umem->config.comp_size * sizeof(__u64));
+	}
 
 	close(umem->fd);
 	free(umem);


### PR DESCRIPTION
xsk_umem__create() does mmap for fill/comp rings, but
xsk_umem__delete() doesn't do the unmap. This works fine for regular
cases, because xsk_socket__delete() does unmap for the rings. But for
the case that xsk_socket__create_shared() fails, umem rings are not
unmapped.

fill_save/comp_save are checked to determine if rings have already be
unmapped by xsk. If fill_save and comp_save are NULL, it means that
the rings have already been used by xsk. Then they are supposed to be
unmapped by xsk_socket__delete(). Otherwise, xsk_umem__delete() does
the unmap.

Note that when I activate Linux style in Emacs, it finds one place in
a comment with an extra space that it fixes as a bonus.

Fixes: ea481a18ed07 ("libxdp: move AF_XDP functionality from libbpf")
Signed-off-by: Cheng Li <lic121@chinatelecom.cn>