### PR TITLE
libxdp: Expose xdp_program__clone()

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -60,6 +60,8 @@ struct xdp_program *xdp_program__open_file(const char *filename,
 struct xdp_program *xdp_program__from_fd(int fd);
 struct xdp_program *xdp_program__from_id(__u32 prog_id);
 struct xdp_program *xdp_program__from_pin(const char *pin_path);
+struct xdp_program *xdp_program__clone(struct xdp_program *xdp_prog,
+                                       unsigned int flags);
 
 void xdp_program__close(struct xdp_program *xdp_prog);
 

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -69,5 +69,6 @@ LIBXDP_1.2.0 {
 } LIBXDP_1.0.0;
 
 LIBXDP_1.3.0 {
+		xdp_program__clone;
 		xdp_program__create;
 } LIBXDP_1.2.0;

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -44,7 +44,6 @@ LIBXDP_HIDE_SYMBOL __printf(2, 3) void libxdp_print(enum libxdp_print_level leve
 
 LIBXDP_HIDE_SYMBOL int check_xdp_prog_version(const struct btf *btf, const char *name,
 					      __u32 *version);
-LIBXDP_HIDE_SYMBOL struct xdp_program *xdp_program__clone(struct xdp_program *prog);
 
 #define min(x, y) ((x) < (y) ? x : y)
 #define max(x, y) ((x) > (y) ? x : y)

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -670,7 +670,7 @@ check:
 
 out:
 	if (!IS_ERR_OR_NULL(prog))
-		prog = xdp_program__clone(prog);
+		prog = xdp_program__clone(prog, 0);
 
 	xdp_multiprog__close(multi_prog);
 	return prog;


### PR DESCRIPTION
Library users may need to clone xdp_program objects, so expose the internal
xdp_program__clone() method to do this. Add a flags argument for future
extensibility, and also handle unloaded xdp_program instances, by creating
a new program with an external reference to the same bpf_object.

Fixes #183.