### PR TITLE
lib/testing: Don't use deprecated section name for test object file

### DIFF
--- a/lib/testing/test_long_func_name.c
+++ b/lib/testing/test_long_func_name.c
@@ -9,14 +9,14 @@
 				 ##__VA_ARGS__);	\
 	}
 
-SEC("xdp_test_prog_long")
+SEC("xdp")
 int xdp_test_prog_with_a_long_name(struct xdp_md *ctx)
 {
 	bpf_debug("PASS[1]: prog %u\n", ctx->ingress_ifindex);
 	return XDP_PASS;
 }
 
-SEC("xdp_test_prog_long_II")
+SEC("xdp")
 int xdp_test_prog_with_a_long_name_too(struct xdp_md *ctx)
 {
 	bpf_debug("PASS[2]: prog %u\n", ctx->ingress_ifindex);


### PR DESCRIPTION
Arbitrary section names are deprecated in libbpf, so don't use them in our
test object files (or things will break once libbpf 1.0 removes the support
entirely).

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>