### PR TITLE
configure: Don't check for bpf_set_link_xdp_fd_opts()

### DIFF
--- a/configure
+++ b/configure
@@ -260,12 +260,10 @@ check_libbpf()
 int main(int argc, char **argv) {
     void *ptr;
     DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts, .pin_root_path = "/path");
-    DECLARE_LIBBPF_OPTS(bpf_xdp_set_link_opts, xlopts, .old_fd = -1);
     DECLARE_LIBBPF_OPTS(bpf_link_create_opts, lopts, .target_btf_id = 0);
     (void) bpf_object__open_file("file", &opts);
     (void) bpf_program__name(ptr);
     (void) bpf_map__set_initial_value(ptr, ptr, 0);
-    (void) bpf_set_link_xdp_fd_opts(0, 0, 0, &xlopts);
     return 0;
 }
 EOF


### PR DESCRIPTION
The configure script checks for the presence of the old_fd argument in
bpf_set_link_xdp_fd_opts() to determine if it can use the system libbpf.
However, this function has been deprecated in newer versions of libbpf,
which means we refuse to use system libbpf versions 0.8 and above.
Fortunately, we can just remove this check, as we also check for
bpf_map__set_initial_value() which was added after the old_fd support.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>