### PR TITLE
libxdp: Introduce refcount

### DIFF
--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -18,9 +18,6 @@ MAN_PAGE := libxdp.3
 MAN_OBJ := ${MAN_PAGE:.3=.man}
 MAN_FILES := $(MAN_PAGE)
 TEST_DIR := tests
-TEST_FILE := $(TEST_DIR)/test-libxdp.sh
-TEST_CFLAGS := $(CFLAGS) -I$(realpath $(HEADER_DIR)) -L$(realpath $(OBJDIR)) -Wall -Werror $(LDFLAGS)
-TEST_LDLIBS := $(LDLIBS)
 
 SHARED_CFLAGS += -fPIC -DSHARED
 LIB_HEADERS := $(wildcard $(HEADER_DIR)/xdp/*.h)
@@ -47,6 +44,7 @@ clean:
 	$(Q)rm -f $(STATIC_LIBS) $(STATIC_OBJS) $(SHARED_LIBS) $(SHARED_OBJS) $(XDP_OBJS) $(PC_FILE) $(MAN_OBJ) $(TEMPLATED_SOURCES)
 	$(Q)for d in $(SHARED_OBJDIR) $(STATIC_OBJDIR); do \
 		[ -d "$$d" ] && rmdir "$$d"; done || true
+	$(Q)$(MAKE) -C $(TEST_DIR) clean
 
 install: all
 	$(Q)install -d -m 0755 $(DESTDIR)$(HDRDIR)
@@ -166,4 +164,4 @@ endif
 
 .PHONY: test
 test: all
-	$(Q)env CC="$(CC)" CFLAGS="$(TEST_CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(TEST_LDLIBS)" V=$(V) $(TEST_DIR)/test_runner.sh $(TEST_FILE)
+	$(Q)$(MAKE) -C $(TEST_DIR) run

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -470,7 +470,7 @@ static const char *get_lock_dir(void)
 	return dir;
 }
 
-static int xdp_lock_acquire(void)
+int xdp_lock_acquire(void)
 {
 	int lock_fd, err;
 	const char *dir;
@@ -499,7 +499,7 @@ static int xdp_lock_acquire(void)
 	return lock_fd;
 }
 
-static int xdp_lock_release(int lock_fd)
+int xdp_lock_release(int lock_fd)
 {
 	int err;
 

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -136,4 +136,7 @@ static inline void *libxdp_err_ptr(int err, bool ret_null)
 	return ERR_PTR(err);
 }
 
+LIBXDP_HIDE_SYMBOL int xdp_lock_acquire(void);
+LIBXDP_HIDE_SYMBOL int xdp_lock_release(int lock_fd);
+
 #endif /* __LIBXDP_LIBXDP_INTERNAL_H */

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+USER_TARGETS := test_xsk_refcnt
+USER_LIBS := -lpthread
+
+EXTRA_DEPS +=
+EXTRA_USER_DEPS += test_utils.h
+
+TEST_FILE := ./test-libxdp.sh
+TEST_RUNNER := ./test_runner.sh
+
+USER_C := ${USER_TARGETS:=.c}
+USER_OBJ := ${USER_C:.c=.o}
+
+LIB_DIR := ../..
+LDLIBS += $(USER_LIBS)
+
+include $(LIB_DIR)/defines.mk
+
+LDFLAGS+=-L$(LIBXDP_DIR)
+ifeq ($(DYNAMIC_LIBXDP),1)
+	LDLIBS:=-lxdp $(LDLIBS)
+	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.so.$(LIBXDP_VERSION)
+else
+	LDLIBS:=-l:libxdp.a $(LDLIBS)
+	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.a
+endif
+
+# Detect submodule libbpf source file changes
+ifeq ($(SYSTEM_LIBBPF),n)
+	LIBBPF_SOURCES := $(wildcard $(LIBBPF_DIR)/src/*.[ch])
+endif
+
+LIBXDP_SOURCES := $(wildcard $(LIBXDP_DIR)/*.[ch] $(LIBXDP_DIR)/*.in)
+
+CFLAGS += -I$(HEADER_DIR)
+
+BPF_HEADERS := $(wildcard $(HEADER_DIR)/bpf/*.h) $(wildcard $(HEADER_DIR)/xdp/*.h)
+
+all: $(USER_TARGETS)
+
+.PHONY: clean
+clean::
+	$(Q)rm -f $(USER_TARGETS) $(USER_OBJ)
+
+$(OBJECT_LIBBPF): $(LIBBPF_SOURCES)
+	$(Q)$(MAKE) -C $(LIB_DIR) libbpf
+
+$(OBJECT_LIBXDP): $(LIBXDP_SOURCES)
+	$(Q)$(MAKE) -C $(LIBXDP_DIR)
+
+# Create expansions for dependencies
+LIB_H := ${LIB_OBJS:.o=.h}
+
+# Detect if any of common obj changed and create dependency on .h-files
+$(LIB_OBJS): %.o: %.c %.h $(LIB_H)
+	$(Q)$(MAKE) -C $(dir $@) $(notdir $@)
+
+ALL_EXEC_TARGETS=$(USER_TARGETS)
+$(ALL_EXEC_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OBJS) $(EXTRA_DEPS) $(EXTRA_USER_DEPS)
+	$(QUIET_CC)$(CC) -Wall $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(LIB_OBJS) \
+	 $< $(LDLIBS)
+
+run: all
+	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" V=$(V) $(TEST_RUNNER) $(TEST_FILE)

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -1,4 +1,8 @@
-ALL_TESTS="test_link_so test_link_a"
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+ALL_TESTS="test_link_so test_link_a test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy"
+
+TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 test_link_so()
 {
@@ -24,4 +28,35 @@ int main(int argc, char **argv) {
 }
 EOF
         check_run $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -l:libxdp.a $LDLIBS 2>&1
+}
+
+test_refcnt_once()
+{
+	# We need multiple queues for this test
+	NUM_QUEUES_REQUIRED=3
+        ip link add xsk_veth0 numrxqueues $NUM_QUEUES_REQUIRED type veth peer name xsk_veth1
+        check_run $TESTS_DIR/test_xsk_refcnt xsk_veth0 2>&1
+        ip link delete xsk_veth0
+}
+
+check_mount_bpffs()
+{
+	mount | grep -q /sys/fs/bpf || mount -t bpf bpf /sys/fs/bpf/ || echo "Unable to mount /sys/fs/bpf"
+	mount | grep -q /sys/fs/bpf
+}
+
+check_unmount_bpffs()
+{
+	mount | grep -q /sys/fs/bpf && umount /sys/fs/bpf/ || echo "Unable to unmount /sys/fs/bpf"
+	! mount | grep -q /sys/fs/bpf
+}
+
+test_xsk_prog_refcnt_bpffs()
+{
+	check_mount_bpffs && test_refcnt_once "$@"
+}
+
+test_xsk_prog_refcnt_legacy()
+{
+	check_unmount_bpffs && test_refcnt_once "$@"
 }

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -92,6 +92,14 @@ usage()
     exit 1
 }
 
+if [ "$EUID" -ne "0" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+        exec sudo env CC="$CC" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" LDLIBS="$LDLIBS" V=${VERBOSE_TESTS} "$0" "$@"
+    else
+        die "Tests must be run as root"
+    fi
+fi
+
 TEST_DEFINITIONS="${1:-}"
 [ -f "$TEST_DEFINITIONS" ] || usage
 source "$TEST_DEFINITIONS"

--- a/lib/libxdp/tests/test_utils.h
+++ b/lib/libxdp/tests/test_utils.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __TEST_UTILS_H
+#define __TEST_UTILS_H
+
+#include <bpf/libbpf.h>
+
+#define __unused __attribute__((unused))
+
+static int libbpf_silent_func(__unused enum libbpf_print_level level,
+			      __unused const char *format,
+			      __unused va_list args)
+{
+	return 0;
+}
+
+static void silence_libbpf_logging(void)
+{
+	libbpf_set_print(libbpf_silent_func);
+}
+
+#endif

--- a/lib/libxdp/tests/test_xsk_refcnt.c
+++ b/lib/libxdp/tests/test_xsk_refcnt.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <errno.h>
+#include <linux/err.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+
+#include <xdp/libxdp.h>
+#include <xdp/xsk.h>
+
+typedef __u64 u64;
+typedef __u32 u32;
+typedef __u16 u16;
+typedef __u8  u8;
+
+#define MAX_EVENTS 10
+#define MAX_NUM_QUEUES 4
+#define TEST_NAME_LENGTH 128
+
+struct xsk_umem_info {
+	struct xsk_ring_prod fq;
+	struct xsk_ring_cons cq;
+	struct xsk_umem *umem;
+	void *buffer;
+};
+
+struct xsk_socket_info {
+	struct xsk_ring_cons rx;
+	struct xsk_umem_info *umem;
+	struct xsk_socket *xsk;
+};
+
+/* Event holds socket operations that are run concurrently
+ * and in theory can produce a race condition
+ */
+struct xsk_test_event {
+	u32 num_create;
+	u32 num_delete;
+	u32 create_qids[MAX_NUM_QUEUES];	/* QIDs for sockets being created in this event */
+	u32 delete_qids[MAX_NUM_QUEUES];	/* QIDs for sockets being deleted in this event */
+};
+
+struct xsk_test {
+	char name[TEST_NAME_LENGTH];
+	u32 num_events;
+	struct xsk_test_event events[MAX_EVENTS];
+};
+
+/* Tests that use less queues must come first,
+ * so we can run all possible tests on VMs with
+ * small number of CPUs
+ */
+static struct xsk_test all_tests[] = {
+	{ "Single socket created and deleted",
+	  .num_events = 2,
+	  .events = {{ .num_create = 1, .create_qids = {0} },
+		     { .num_delete = 1, .delete_qids = {0} }
+		    }},
+	{ "2 sockets, created and deleted sequentially",
+	  .num_events = 4,
+	  .events = {{ .num_create = 1, .create_qids = {0} },
+		     { .num_create = 1, .create_qids = {1} },
+		     { .num_delete = 1, .delete_qids = {0} },
+		     { .num_delete = 1, .delete_qids = {1} }
+		    }},
+	{ "2 sockets, created sequentially and deleted asynchronously",
+	   .num_events = 3,
+	   .events = {{ .num_create = 1, .create_qids = {0} },
+		      { .num_create = 1, .create_qids = {1} },
+		      { .num_delete = 2, .delete_qids = {0, 1} }
+		     }},
+	{ "2 sockets, asynchronously delete and create",
+	  .num_events = 3,
+	  .events = {{ .num_create = 1, .create_qids = {0} },
+		     { .num_create = 1, .create_qids = {1},
+		       .num_delete = 1, .delete_qids = {0} },
+		     { .num_delete = 1, .delete_qids = {1} }
+		    }},
+	{ "3 sockets, created and deleted sequentially",
+	  .num_events = 6,
+	  .events = {{ .num_create = 1, .create_qids = {0} },
+		     { .num_create = 1, .create_qids = {1} },
+		     { .num_create = 1, .create_qids = {2} },
+		     { .num_delete = 1, .delete_qids = {1} },
+		     { .num_delete = 1, .delete_qids = {2} },
+		     { .num_delete = 1, .delete_qids = {0} }
+		    }},
+};
+
+# define ARRAY_SIZE(_x) (sizeof(_x) / sizeof((_x)[0]))
+
+static const char *opt_if;
+static const u8 num_tests = ARRAY_SIZE(all_tests);
+
+static struct xsk_socket_info *xsks[MAX_NUM_QUEUES];
+
+#define FRAME_SIZE 64
+#define NUM_FRAMES (XSK_RING_CONS__DEFAULT_NUM_DESCS * 2)
+
+static struct xsk_umem_info *xsk_configure_umem(void *buffer, u64 size)
+{
+	struct xsk_umem_info *umem;
+	int ret;
+
+	umem = calloc(1, sizeof(*umem));
+	if (!umem)
+		exit(EXIT_FAILURE);
+
+	ret = xsk_umem__create(&umem->umem, buffer, size, &umem->fq, &umem->cq,
+			       NULL);
+	if (ret)
+		exit(ret);
+
+	umem->buffer = buffer;
+	return umem;
+}
+
+static struct xsk_socket_info *xsk_configure_socket(struct xsk_umem_info *umem,
+						    unsigned int qid)
+{
+	struct xsk_socket_config cfg = {};
+	struct xsk_socket_info *xsk;
+	struct xsk_ring_cons *rxr;
+
+	xsk = calloc(1, sizeof(*xsk));
+	if (!xsk)
+		exit(EXIT_FAILURE);
+
+	xsk->umem = umem;
+	cfg.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS;
+
+	rxr = &xsk->rx;
+	xsk_socket__create(&xsk->xsk, opt_if, qid, umem->umem,
+			   rxr, NULL, &cfg);
+
+	return xsk;
+}
+
+static void *create_socket(void *args)
+{
+	struct xsk_umem_info *umem;
+	u32 qid = *(u32 *)args;
+	void *buffs;
+
+	if (posix_memalign(&buffs,
+			   getpagesize(), /* PAGE_SIZE aligned */
+			   NUM_FRAMES * FRAME_SIZE)) {
+		fprintf(stderr, "ERROR: Can't allocate buffer memory \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	umem = xsk_configure_umem(buffs, NUM_FRAMES * FRAME_SIZE);
+	xsks[qid] = xsk_configure_socket(umem, qid);
+
+	return NULL;
+}
+
+static void *delete_socket(void *args)
+{
+	u32 qid = *(u32 *)args;
+	struct xsk_umem *umem;
+	void *buff;
+
+	buff = xsks[qid]->umem->buffer;
+	umem = xsks[qid]->umem->umem;
+	xsk_socket__delete(xsks[qid]->xsk);
+	free(buff);
+	(void)xsk_umem__delete(umem);
+
+	return NULL;
+}
+
+static bool xsk_prog_attached(void)
+{
+	char xsk_prog_name[] = "xsk_def_prog";
+	int ifindex = if_nametoindex(opt_if);
+	struct xdp_program *xsk_prog;
+	struct xdp_multiprog *mp;
+	bool answer = false;
+
+	mp = xdp_multiprog__get_from_ifindex(ifindex);
+	if (IS_ERR_OR_NULL(mp))
+		return false;
+
+	xsk_prog = xdp_multiprog__is_legacy(mp) ? xdp_multiprog__main_prog(mp) :
+						  xdp_multiprog__next_prog(NULL, mp);
+
+	if (IS_ERR_OR_NULL(xsk_prog))
+		goto free_mp;
+
+	answer = !strncmp(xsk_prog_name, xdp_program__name(xsk_prog),
+			  sizeof(xsk_prog_name));
+free_mp:
+	xdp_multiprog__close(mp);
+	return answer;
+}
+
+static void update_reference_refcnt(struct xsk_test_event *event, int *refcnt)
+{
+	*refcnt += event->num_create;
+	*refcnt -= event->num_delete;
+}
+
+static bool check_run_event(struct xsk_test_event *event, int *refcnt)
+{
+	pthread_t threads[MAX_NUM_QUEUES];
+	bool prog_attached, prog_needed;
+	u8 thread_num = 0, i;
+	int ret;
+
+	update_reference_refcnt(event, refcnt);
+
+	for (i = 0; i < event->num_create; i++) {
+		ret = pthread_create(&threads[thread_num++], NULL,
+				     &create_socket, &event->create_qids[i]);
+		if (ret)
+			exit(ret);
+	}
+
+	for (i = 0; i < event->num_delete; i++) {
+		ret = pthread_create(&threads[thread_num++], NULL,
+				     &delete_socket, &event->delete_qids[i]);
+		if (ret)
+			exit(ret);
+	}
+
+	for (i = 0; i < thread_num; i++)
+		pthread_join(threads[i], NULL);
+
+	prog_attached = xsk_prog_attached();
+	prog_needed = *refcnt > 0;
+
+	if (prog_needed != prog_attached) {
+		printf("Program is referenced by %d sockets, but is %s attached\n",
+		       *refcnt, prog_attached ? "still" : "not");
+		return false;
+	}
+
+	return true;
+}
+
+static bool check_run_test(struct xsk_test *test)
+{
+	bool test_ok = false;
+	int refcnt = 0;
+	u8 i = 0;
+
+	for (i = 0; i < test->num_events; i++) {
+		if (!check_run_event(&test->events[i], &refcnt)) {
+			printf("Event %u failed\n", i);
+			goto print_result;
+		}
+	}
+
+	/* Do not let tests interfere with each other */
+	sleep(1);
+
+	test_ok = true;
+
+print_result:
+	printf("%s: %s\n", test->name, test_ok ? "PASSED" : "FAILED");
+	return test_ok;
+}
+
+static int read_args(int argc, char **argv)
+{
+	if (argc != 2)
+		return -1;
+
+	opt_if = argv[1];
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	u8 i = 0;
+
+	if (read_args(argc, argv))
+		return -1;
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	silence_libbpf_logging();
+
+	for (i = 0; i < num_tests; i++) {
+		if (!check_run_test(&all_tests[i]))
+			exit(EXIT_FAILURE);
+	}
+
+	return 0;
+}

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -652,6 +652,7 @@ static struct xdp_program *xsk_lookup_program(int ifindex)
 
 	if (xdp_multiprog__is_legacy(multi_prog)) {
 		prog = xdp_multiprog__main_prog(multi_prog);
+		prog = strcmp(xdp_program__name(prog), prog_name) ? NULL : prog;
 		goto check;
 	}
 
@@ -659,10 +660,10 @@ static struct xdp_program *xsk_lookup_program(int ifindex)
 		if (!strcmp(xdp_program__name(prog), prog_name))
 			break;
 
+check:
 	if (!prog)
 		goto out;
 
-check:
 	err = check_xdp_prog_version(xdp_program__btf(prog), version_name, &version);
 	if (err) {
 		prog = ERR_PTR(err);

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -77,6 +77,7 @@ struct xsk_ctx {
 	int xsks_map_fd;
 	struct list_head list;
 	struct xdp_program *xdp_prog;
+	int refcnt_map_fd;
 	char ifname[IFNAMSIZ];
 };
 
@@ -502,7 +503,8 @@ static void xsk_delete_map_entry(int xsks_map_fd, __u32 queue_id)
 	close(xsks_map_fd);
 }
 
-static int xsk_lookup_bpf_map(int prog_fd)
+static int xsk_lookup_map_by_filter(int prog_fd,
+				    bool (*map_info_filter)(struct bpf_map_info *map_info))
 {
 	__u32 i, *map_ids, num_maps, prog_len = sizeof(struct bpf_prog_info);
 	__u32 map_len = sizeof(struct bpf_map_info);
@@ -542,8 +544,7 @@ static int xsk_lookup_bpf_map(int prog_fd)
 			continue;
 		}
 
-		if (!strncmp(map_info.name, "xsks_map", sizeof(map_info.name)) &&
-		    map_info.key_size == 4 && map_info.value_size == 4) {
+		if (map_info_filter(&map_info)) {
 			xsks_map_fd = fd;
 			break;
 		}
@@ -553,6 +554,51 @@ static int xsk_lookup_bpf_map(int prog_fd)
 
 	free(map_ids);
 	return xsks_map_fd;
+}
+
+static bool xsk_map_is_socket_map(struct bpf_map_info *map_info)
+{
+	return !strncmp(map_info->name, "xsks_map", sizeof(map_info->name)) &&
+		map_info->key_size == 4 && map_info->value_size == 4;
+}
+
+static bool xsk_map_is_refcnt_map(struct bpf_map_info *map_info)
+{
+	/* In order to avoid confusing users with multiple identically named
+	 * maps, libbpf names non-custom internal maps (.data, .bss, etc.)
+	 * in an unexpected way, namely the first 8 characters of a bpf object
+	 * name + a suffix signifying the internal map type,
+	 * ex. "xdp_def_" + ".data".
+	 */
+	return !strncmp(map_info->name, "xsk_def_.data",
+			sizeof(map_info->name)) &&
+			map_info->value_size >= sizeof(int);
+}
+
+static int xsk_lookup_bpf_map(int prog_fd)
+{
+	return xsk_lookup_map_by_filter(prog_fd, &xsk_map_is_socket_map);
+}
+
+static int xsk_lookup_refcnt_map(int prog_fd, const char *xdp_filename)
+{
+	int map_fd = xsk_lookup_map_by_filter(prog_fd, &xsk_map_is_refcnt_map);
+
+	if (map_fd >= 0)
+		goto out;
+
+	if (map_fd != -ENOENT) {
+		pr_debug("Error getting refcount map: %s\n", strerror(-map_fd));
+		goto out;
+	}
+
+	if (xdp_filename)
+		pr_warn("Refcount was not found in %s or kernel does not support required features, so automatic program removal on unload is disabled\n",
+			xdp_filename);
+	else
+		pr_warn("Another XSK socket was created by a version of libxdp that doesn't support program refcnt, so automatic program removal on unload is disabled.\n");
+out:
+	return map_fd;
 }
 
 #ifdef HAVE_LIBBPF_BPF_MAP_CREATE
@@ -683,18 +729,103 @@ out:
 	return prog;
 }
 
+static int xsk_update_prog_refcnt(int refcnt_map_fd, int delta)
+{
+	struct bpf_map_info map_info = {};
+	__u32 info_len = sizeof(map_info);
+	int *value_data = NULL;
+	int lock_fd, ret;
+	__u32 key = 0;
+
+	ret = bpf_obj_get_info_by_fd(refcnt_map_fd, &map_info, &info_len);
+	if (ret)
+		return ret;
+
+	value_data = malloc(map_info.value_size);
+	if (!value_data)
+		return -ENOMEM;
+
+	lock_fd = xdp_lock_acquire();
+	if (lock_fd < 0)
+		return lock_fd;
+
+	/* Note, if other global variables are added before the refcnt,
+	 * this changes map's value type, not number of elements,
+	 * so additional offset must be applied to value_data,
+	 * when reading refcount, but map key always stays zero
+	 */
+	ret = bpf_map_lookup_elem(refcnt_map_fd, &key, value_data);
+	if (ret)
+		goto unlock;
+
+	/* If refcount is 0, program is awaiting detach and can't be used */
+	if (*value_data) {
+		*value_data += delta;
+		ret = bpf_map_update_elem(refcnt_map_fd, &key, value_data, 0);
+		if (ret)
+			goto unlock;
+	}
+
+	ret = *value_data;
+unlock:
+	xdp_lock_release(lock_fd);
+	free(value_data);
+	return ret;
+}
+
+static int xsk_incr_prog_refcnt(int refcnt_map_fd)
+{
+	return xsk_update_prog_refcnt(refcnt_map_fd, 1);
+}
+
+static int xsk_decr_prog_refcnt(int refcnt_map_fd)
+{
+	return xsk_update_prog_refcnt(refcnt_map_fd, -1);
+}
+
 static int __xsk_setup_xdp_prog(struct xsk_socket *xsk, int *xsks_map_fd)
 {
 	const char *fallback_prog = "xsk_def_xdp_prog_5.3.o";
 	const char *default_prog = "xsk_def_xdp_prog.o";
 	struct xsk_ctx *ctx = xsk->ctx;
-	const char *file_name;
+	const char *file_name = NULL;
 	bool attached = false;
 	int err;
 
 	ctx->xdp_prog = xsk_lookup_program(ctx->ifindex);
 	if (IS_ERR(ctx->xdp_prog))
 		return PTR_ERR(ctx->xdp_prog);
+
+	ctx->refcnt_map_fd = -ENOENT;
+
+	if (ctx->xdp_prog) {
+		int refcnt;
+
+		ctx->refcnt_map_fd = xsk_lookup_refcnt_map(xdp_program__fd(ctx->xdp_prog), NULL);
+		if (ctx->refcnt_map_fd == -ENOENT)
+			goto map_lookup;
+
+		if (ctx->refcnt_map_fd < 0) {
+			err = ctx->refcnt_map_fd;
+			goto err_prog_load;
+		}
+
+		refcnt = xsk_incr_prog_refcnt(ctx->refcnt_map_fd);
+		if (refcnt < 0) {
+			err = refcnt;
+			pr_debug("Error occurred when incrementing xsk XDP prog refcount: %s\n",
+				 strerror(-err));
+			goto err_prog_load;
+		}
+
+		if (!refcnt) {
+			pr_warn("Current program is being detached, falling back on creating a new program\n");
+			close(ctx->refcnt_map_fd);
+			ctx->refcnt_map_fd = -ENOENT;
+			xdp_program__close(ctx->xdp_prog);
+			ctx->xdp_prog = NULL;
+		}
+	}
 
 	if (!ctx->xdp_prog) {
 		file_name = xsk_check_redirect_flags() ? default_prog : fallback_prog;
@@ -714,6 +845,15 @@ static int __xsk_setup_xdp_prog(struct xsk_socket *xsk, int *xsks_map_fd)
 		attached = true;
 	}
 
+	if (ctx->refcnt_map_fd < 0) {
+		ctx->refcnt_map_fd = xsk_lookup_refcnt_map(xdp_program__fd(ctx->xdp_prog),
+							   file_name);
+		if (ctx->refcnt_map_fd < 0 && ctx->refcnt_map_fd != -ENOENT) {
+			err = ctx->refcnt_map_fd;
+			goto err_prog_load;
+		}
+	}
+map_lookup:
 	ctx->xsks_map_fd = xsk_lookup_bpf_map(xdp_program__fd(ctx->xdp_prog));
 	if (ctx->xsks_map_fd < 0) {
 		err = ctx->xsks_map_fd;
@@ -735,6 +875,9 @@ err_lookup:
 		xdp_program__detach(ctx->xdp_prog, ctx->ifindex,
 				    xsk_convert_xdp_flags(xsk->config.xdp_flags), 0);
 err_prog_load:
+	if (ctx->refcnt_map_fd >= 0)
+		close(ctx->refcnt_map_fd);
+	ctx->refcnt_map_fd = -ENOENT;
 	xdp_program__close(ctx->xdp_prog);
 	ctx->xdp_prog = NULL;
 	return err;
@@ -1092,6 +1235,27 @@ int xsk_umem__delete(struct xsk_umem *umem)
 	return 0;
 }
 
+static void xsk_release_xdp_prog(struct xsk_socket *xsk)
+{
+	struct xsk_ctx *ctx = xsk->ctx;
+	int value;
+
+	if (xsk->ctx->refcnt_map_fd < 0)
+		goto out;
+
+	value = xsk_decr_prog_refcnt(ctx->refcnt_map_fd);
+	if (value < 0)
+		pr_warn("Error occurred when decrementing xsk XDP prog refcount: %s, please detach program yourself\n",
+			strerror(-value));
+	if (value)
+		goto out;
+
+	xdp_program__detach(ctx->xdp_prog, ctx->ifindex,
+			    xsk_convert_xdp_flags(xsk->config.xdp_flags), 0);
+out:
+	xdp_program__close(ctx->xdp_prog);
+}
+
 void xsk_socket__delete(struct xsk_socket *xsk)
 {
 	size_t desc_sz = sizeof(struct xdp_desc);
@@ -1107,7 +1271,7 @@ void xsk_socket__delete(struct xsk_socket *xsk)
 	umem = ctx->umem;
 	if (ctx->xdp_prog) {
 		xsk_delete_map_entry(ctx->xsks_map_fd, ctx->queue_id);
-		xdp_program__close(ctx->xdp_prog);
+		xsk_release_xdp_prog(xsk);
 	}
 
 	err = xsk_get_mmap_offsets(xsk->fd, &off);

--- a/lib/libxdp/xsk_def_xdp_prog.c
+++ b/lib/libxdp/xsk_def_xdp_prog.c
@@ -20,10 +20,20 @@ struct {
 	__uint(XDP_PASS, 1);
 } XDP_RUN_CONFIG(xsk_def_prog);
 
+/* Program refcount, in order to work properly,
+ * must be declared before any other global variables
+ * and initialized with '1'.
+ */
+volatile int refcnt = 1;
+
 /* This is the program for post 5.3 kernels. */
 SEC("xdp")
 int xsk_def_prog(struct xdp_md *ctx)
 {
+	/* Make sure refcount is referenced by the program */
+	if (!refcnt)
+		return XDP_PASS;
+
 	/* A set entry here means that the corresponding queue_id
 	 * has an active AF_XDP socket bound to it.
 	 */

--- a/lib/libxdp/xsk_def_xdp_prog_5.3.c
+++ b/lib/libxdp/xsk_def_xdp_prog_5.3.c
@@ -20,11 +20,21 @@ struct {
 	__uint(XDP_PASS, 1);
 } XDP_RUN_CONFIG(xsk_def_prog);
 
+/* Program refcount, in order to work properly,
+ * must be declared before any other global variables
+ * and initialized with '1'.
+ */
+volatile int refcnt = 1;
+
 /* This is the program for 5.3 kernels and older. */
 SEC("xdp")
 int xsk_def_prog(struct xdp_md *ctx)
 {
 	int index = ctx->rx_queue_index;
+
+	/* Make sure refcount is referenced by the program */
+	if (!refcnt)
+		return XDP_PASS;
 
 	/* A set entry here means that the corresponding queue_id
 	 * has an active AF_XDP socket bound to it.


### PR DESCRIPTION
*Currently, if multiple userspace consumers reference the program,
when one of them decides to clean-up and detach the program,
others can not use it anymore. The most obvoius example of such
situation is AF_XDP. In libbpf it was resolved with the bpf_link
abstraction by commit 10397994d30f (libbpf: xsk: Use bpf_link),
but this is not an option in libxdp due to the heavy usage of pinning.*

*Therefore we need to have a separate refcount mechanism.*

This PR shows one way of doing this (details in the commit message).
I mainly expect a feedback on the concept itself.
I will probably refactor some stuff, if it isn't be rejected altogether.

I've tested the basic use cases, so it does certainly work.

If the concept is approved, the following commits will follow:
- refcount API for the xdp-loader
- refcount test
- update lib/libxdp/protocol.org
- use refcount in xsk, this should now work as with bpf_link in libbpf:
    - if xsk XDP prog is present in multiprog, clone it
    - else, create new prog from file
    - attach new/cloned program
    - do normal AF_XDP stuff
    - detach previously attached program
- use bpf_link for xsk in legacy mode (I already have a working code)

Please tell, if I'm missing anything.

Signed-off-by: Larysa Zaremba <larysa.zaremba@intel.com>