### PR TITLE
libxdp: Drop linux/in.h include for XDP dispatcher

### DIFF
--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -7,7 +7,6 @@ define(`NUM_PROGS',ifdef(`MAX_DISPATCHER_ACTIONS', MAX_DISPATCHER_ACTIONS, `10')
 divert(0)dnl
 
 #include <linux/bpf.h>
-#include <linux/in.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 


### PR DESCRIPTION
Including <linux/in.h> is not actually necessary for the XDP
dispatcher, so drop the redundant include.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>