### PR TITLE
man pages: Reformat to support NAME heading for proper whatis processing

### DIFF
--- a/lib/export-man.el
+++ b/lib/export-man.el
@@ -31,7 +31,7 @@
   "Replace REGEXP with REPLACE in buffer."
   (let ((case-fold-search nil))
     (goto-char 0)
-    (while (re-search-forward regexp nil t)
+    (when (re-search-forward regexp nil t)
       (replace-match replace))))
 
 (defun open-file (filename)
@@ -55,6 +55,8 @@
       (mapc #'(lambda (r) (delete-matching-lines r)) exclude-regexes)
       (replace-regexp-in-buffer "DATE" date)
       (replace-regexp-in-buffer "VERSION" version)
+      (replace-regexp-in-buffer "^.SH \"\\([^\"]+\\) - \\([^\"]+\\)\""
+                                ".SH \"NAME\"\n\\1 \\\\- \\2\n.SH \"SYNOPSIS\"")
       (save-buffer))))
 
 (defun export-man-page (outfile infile enabled-features version)

--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -160,7 +160,7 @@ $(MAN_OBJ): README.org $(LIBMK)
 $(MAN_PAGE): $(MAN_OBJ) $(LIBMK)
 	$(QUIET_GEN)MODDATE=$$(git log -1 --pretty="format:%cI" README.org 2>/dev/null); \
 		[ "$$?" -eq "0" ] && DATE=$$(date '+%B %_d, %Y' -d "$$MODDATE") || DATE=$$(date '+%B %_d, %Y'); \
-		sed -e "1 s/DATE/$$DATE/" -e "1 s/VERSION/v$(TOOLS_VERSION)/" $< > $@
+		sed -e "1 s/DATE/$$DATE/" -e "1 s/VERSION/v$(TOOLS_VERSION)/" -e '1,5 s/^.SH "\([^"]\+\) - \([^"]\+\)"/.SH "NAME"\n\1 \\- \2\n.SH "SYNOPSIS"/' $< > $@
 
 endif
 

--- a/lib/libxdp/libxdp.3
+++ b/lib/libxdp/libxdp.3
@@ -1,6 +1,8 @@
 .TH "libxdp" "3" "January 10, 2022" "v1.2.2" "libxdp - library for loading XDP programs" 
 
-.SH "libxdp - library for attaching XDP programs and using AF_XDP sockets"
+.SH "NAME"
+libxdp \- library for attaching XDP programs and using AF_XDP sockets
+.SH "SYNOPSIS"
 .PP
 This directory contains the files for the \fIlibxdp\fP library for
 attaching XDP programs to network interfaces and using AF_XDP

--- a/xdp-dump/xdpdump.8
+++ b/xdp-dump/xdpdump.8
@@ -1,6 +1,8 @@
 .TH "xdpdump" "8" "JANUARY 13, 2021" "V1.2.2" "a simple tcpdump like tool for capturing packets at the XDP layer" 
 
-.SH "xdpdump - a simple tcpdump like tool for capturing packets at the XDP layer"
+.SH "NAME"
+xdpdump \- a simple tcpdump like tool for capturing packets at the XDP layer
+.SH "SYNOPSIS"
 .PP
 \fIxdpdump\fP is a simple XDP packet capture tool that tries to behave similar to
 \fItcpdump\fP, however, it has no packet filter or decode capabilities.

--- a/xdp-filter/README.org
+++ b/xdp-filter/README.org
@@ -7,7 +7,7 @@
 # To export the man page, simply use the org-mode exporter; (require 'ox-man) if
 # it's not available. There's also a Makefile rule to export it.
 
-* XDP-filter - a simple XDP-powered packet filter
+* xdp-filter - a simple XDP-powered packet filter
 
 XDP-filter is a packet filtering utility powered by XDP. It is deliberately
 simple and so does not have the same matching capabilities as, e.g., netfilter.

--- a/xdp-filter/xdp-filter.8
+++ b/xdp-filter/xdp-filter.8
@@ -1,6 +1,8 @@
-.TH "xdp-filter" "8" "JULY 10, 2020" "V1.2.2" "A simple XDP-powered packet filter" 
+.TH "xdp-filter" "8" "AUGUST  9, 2022" "V1.2.2" "A simple XDP-powered packet filter"
 
-.SH "XDP-filter - a simple XDP-powered packet filter"
+.SH "NAME"
+xdp-filter \- a simple XDP-powered packet filter
+.SH "SYNOPSIS"
 .PP
 XDP-filter is a packet filtering utility powered by XDP. It is deliberately
 simple and so does not have the same matching capabilities as, e.g., netfilter.

--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -8,7 +8,7 @@
 # To export the man page, simply use the org-mode exporter; (require 'ox-man) if
 # it's not available. There's also a Makefile rule to export it.
 
-* XDP-loader - an XDP program loader
+* xdp-loader - an XDP program loader
 
 XDP-loader is a simple loader for XDP programs with support for attaching
 multiple programs to the same interface. To achieve this it exposes the same

--- a/xdp-loader/xdp-loader.8
+++ b/xdp-loader/xdp-loader.8
@@ -1,6 +1,8 @@
-.TH "xdp-loader" "8" "FEBRUARY  8, 2022" "V1.2.2" "XDP program loader" 
+.TH "xdp-loader" "8" "AUGUST  9, 2022" "V1.2.2" "XDP program loader"
 
-.SH "XDP-loader - an XDP program loader"
+.SH "NAME"
+xdp-loader \- an XDP program loader
+.SH "SYNOPSIS"
 .PP
 XDP-loader is a simple loader for XDP programs with support for attaching
 multiple programs to the same interface. To achieve this it exposes the same


### PR DESCRIPTION
The 'whatis' utility expects a man page to start with a NAME section with
the name and a short description of the utility. Add some regex hackery to
make sure our exported man pages conform to this format. For details, see:

https://www.mit.edu/afs.new/sipb/project/debathena/lintian/www/tags/manpage-has-bad-whatis-entry.html

Reported-by: Luca Boccassi <bluca@debian.org>
Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>