### PR TITLE
xdp-filter: Print error message if updating state map fails

### DIFF
--- a/xdp-filter/xdp-filter.c
+++ b/xdp-filter/xdp-filter.c
@@ -133,6 +133,13 @@ int map_set_flags(int fd, void *key, __u8 flags)
 		 (uint64_t)values[0], flags);
 
 	err = bpf_map_update_elem(fd, key, values, 0);
+	if (err) {
+		err = -errno;
+		if (err == -E2BIG)
+			pr_warn("Couldn't add entry: state map is full\n");
+		else
+			pr_warn("Unable to update state map: %s\n", strerror(-err));
+	}
 
 	free(values);
 	return err;


### PR DESCRIPTION
When updating the state map fails for xdp-filter, it doesn't actually print
any error messages, it just sets the return code as failed. Fix this,
special-casing the most common error (map full), and otherwise just
printing the error message returned by the kernel.

This should (partially) fix #201