### PR TITLE
xsk: Port bpf_link support from libbpf

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -158,6 +158,8 @@ struct xdp_program_opts {
 #define DECLARE_LIBXDP_OPTS DECLARE_LIBBPF_OPTS
 
 struct xdp_program *xdp_program__create(struct xdp_program_opts *opts);
+int xdp_program__detach_by_id(int ifindex, __u32 prog_id,
+			      enum xdp_attach_mode mode);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -209,6 +209,7 @@ int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
  */
 #define XSK_LIBBPF_FLAGS__INHIBIT_PROG_LOAD (1 << 0)
 #define XSK_LIBXDP_FLAGS__INHIBIT_PROG_LOAD (1 << 0)
+#define XSK_LIBXDP_FLAGS__USE_MULTIPROG (1 << 1)
 
 struct xsk_socket_config {
 	__u32 rx_size;
@@ -245,6 +246,7 @@ int xsk_socket__create_shared(struct xsk_socket **xsk_ptr,
 /* Returns 0 for success and -EBUSY if the umem is still in use. */
 int xsk_umem__delete(struct xsk_umem *umem);
 void xsk_socket__delete(struct xsk_socket *xsk);
+__u32 xsk_socket__get_prog_id(struct xsk_socket *xsk);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1786,6 +1786,14 @@ int xdp_program__detach(struct xdp_program *prog, int ifindex,
 	return libxdp_err(xdp_program__detach_multi(&prog, 1, ifindex, mode, flags));
 }
 
+int xdp_program__detach_by_id(int ifindex, __u32 prog_id,
+			      enum xdp_attach_mode mode)
+{
+	struct xdp_program *prog = xdp_program__from_id(prog_id);
+
+	return libxdp_err(xdp_program__detach(prog, ifindex, mode, 0));
+}
+
 void xdp_multiprog__close(struct xdp_multiprog *mp)
 {
 	struct xdp_program *p, *next = NULL;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -71,4 +71,6 @@ LIBXDP_1.2.0 {
 LIBXDP_1.3.0 {
 		xdp_program__clone;
 		xdp_program__create;
+		xsk_socket__get_prog_id;
+		xdp_program__detach_by_id;
 } LIBXDP_1.2.0;

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -136,4 +136,15 @@ static inline void *libxdp_err_ptr(int err, bool ret_null)
 	return ERR_PTR(err);
 }
 
+LIBXDP_HIDE_SYMBOL int xdp_program__try_attach_multi(struct xdp_program **progs, size_t num_progs,
+						     int ifindex, enum xdp_attach_mode mode,
+						     unsigned int flags);
+
+LIBXDP_HIDE_SYMBOL int xdp_program__attach_single(struct xdp_program *prog, int ifindex,
+						  enum xdp_attach_mode mode);
+
+LIBXDP_HIDE_SYMBOL void xdp_adjust_mode_flags(int *xdp_flags, enum xdp_attach_mode mode);
+LIBXDP_HIDE_SYMBOL int xdp_program__load(struct xdp_program *prog);
+LIBXDP_HIDE_SYMBOL struct bpf_program *xdp_program__bpf_prog(struct xdp_program *prog);
+
 #endif /* __LIBXDP_LIBXDP_INTERNAL_H */


### PR DESCRIPTION
It's important to give AF_XDP users at least the same
level of convenience was present in libbpf. This includes
AF_XDP XDP program auto detach when all sockets are closed.

Refcount which would support multiprog requires a lot of discussion,
so let's concentrate on a case users are used to (legacy) for now.
AF_XDP users are less inclined to using multiprog anyway.

1st commit ports bpf_link AF_XDP functionality from libbpf
2nd commit adds a simple API for AF_XDP+multiprog users