### PR TITLE
libxdp: Fix incorrect rx_ring_setup_done

### DIFF
--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -955,7 +955,7 @@ int xsk_socket__create_shared(struct xsk_socket **xsk_ptr,
 			goto out_put_ctx;
 		}
 		if (xsk->fd == umem->fd)
-			umem->rx_ring_setup_done = true;
+			umem->tx_ring_setup_done = true;
 	}
 
 	err = xsk_get_mmap_offsets(xsk->fd, &off);


### PR DESCRIPTION
This has been reported in libbpf ([0]) a year ago and was fixed by
commit 2da7f66d3fc1 ([1]). Let's introduce the fix into libxdp.

  [0]: https://github.com/libbpf/libbpf/issues/259
  [1]: https://github.com/libbpf/libbpf/commit/2da7f66d3fc1

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>