### PR TITLE
xdp-filter: Update examples in documentation

### DIFF
--- a/xdp-filter/README.org
+++ b/xdp-filter/README.org
@@ -271,7 +271,7 @@ To filter all packets *except* those from IP address fc00:dead:cafe::1 issue the
 following commands (careful, this can lock you out of remote access!):
 
 #+begin_src sh
-# xdp-filter load eth0 -f ipv6 -w
+# xdp-filter load eth0 -f ipv6 -p deny
 # xdp-filter ip fc00:dead:cafe::1 -m src
 #+end_src
 
@@ -279,7 +279,7 @@ To allow packets from *either* IP fc00:dead:cafe::1 *or* arriving on port 22,
 issue the following (careful, this can lock you out of remote access!):
 
 #+begin_src sh
-# xdp-filter load eth0 -f ipv6,tcp -w
+# xdp-filter load eth0 -f ipv6,tcp -p deny
 # xdp-filter port 22
 # xdp-filter ip fc00:dead:cafe::1 -m src
 #+end_src

--- a/xdp-filter/xdp-filter.8
+++ b/xdp-filter/xdp-filter.8
@@ -342,7 +342,7 @@ following commands (careful, this can lock you out of remote access!):
 
 .RS
 .nf
-\fC# xdp-filter load eth0 -f ipv6 -w
+\fC# xdp-filter load eth0 -f ipv6 -p deny
 # xdp-filter ip fc00:dead:cafe::1 -m src
 \fP
 .fi
@@ -354,7 +354,7 @@ issue the following (careful, this can lock you out of remote access!):
 
 .RS
 .nf
-\fC# xdp-filter load eth0 -f ipv6,tcp -w
+\fC# xdp-filter load eth0 -f ipv6,tcp -p deny
 # xdp-filter port 22
 # xdp-filter ip fc00:dead:cafe::1 -m src
 \fP


### PR DESCRIPTION
The examples use the outdated flag `-w`. This commit replaces them with the
policy option to achieve the same funcitonality.

Signed-off-by: Tobias Böhm <code@aibor.de>