### PR TITLE
headers: add bpf_endian.h for parsing_helpers.h

### DIFF
--- a/headers/xdp/parsing_helpers.h
+++ b/headers/xdp/parsing_helpers.h
@@ -25,6 +25,7 @@
 #include <linux/udp.h>
 #include <linux/tcp.h>
 #include <linux/in.h>
+#include <bpf/bpf_endian.h>
 
 /* Header cursor to keep track of current parsing position */
 struct hdr_cursor {

--- a/xdp-filter/xdpfilt_prog.h
+++ b/xdp-filter/xdpfilt_prog.h
@@ -12,7 +12,6 @@
 #include <linux/bpf.h>
 #include <linux/in.h>
 #include <bpf/bpf_helpers.h>
-#include <bpf/bpf_endian.h>
 #include <xdp/xdp_helpers.h>
 
 #include "common_kern_user.h"


### PR DESCRIPTION
bpf_endian.h should always be put ahead of parsing_helpers.h,
otherwise loading prog will complain like below:
libbpf: failed to find BTF for extern 'bpf_htons': -2

So to make life easier, add it to the header file directly.

Signed-off-by: junka <wan.junjie@foxmail.com>