### PR TITLE
xdp-filter: update comment in xdpfilt_prog.h

### DIFF
--- a/xdp-filter/xdpfilt_prog.h
+++ b/xdp-filter/xdpfilt_prog.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
 /* XDP filter program fragment. This header file contains the full-featured
- * program, split up with ifdefs. The actual program file in xdp_filt_kern.c
- * includes this file multiple times with different #defines to create the
+ * program, split up with ifdefs. The actual program files xdpfilt_*.c
+ * include this file with different #defines to create the
  * different eBPF program sections that include only the needed features.
  */
 


### PR DESCRIPTION
PR updates the comment on top of xdp-filter/xdpfilt_prog.h as there is no longer a `xdp_filt_kern.c` file.