### PR TITLE
export-man: Ignore errors when executing git shell command

### DIFF
--- a/lib/export-man.el
+++ b/lib/export-man.el
@@ -42,7 +42,8 @@
 
 (defun get-file-mod-time (filename)
   (let* ((file-modtime (file-attribute-modification-time (file-attributes filename)))
-         (git-logtime (shell-command-to-string (format "git log -1 --pretty='format:%%cI' -- %s" filename)))
+         (git-logtime (ignore-errors (shell-command-to-string
+                                      (format "git log -1 --pretty='format:%%cI' -- %s" filename))))
          (git-modtime (ignore-errors (parse-iso8601-time-string git-logtime))))
     (or git-modtime file-modtime)))
 


### PR DESCRIPTION
The export-man Emacs function tries to read the file modification from the
git log, and falls back to the file modification if it can't. However, it
turns out that the shell-command-to-string Emacs function can actually
crash, so we need to wrap it in an 'ignore-errors' macro.

Fixes #240.