### PR TITLE
configure: Copy kernel headers into $TMPDIR/include when testing libb…

### DIFF
--- a/configure
+++ b/configure
@@ -184,7 +184,8 @@ check_libbpf_function()
     if [ -n "$LIBBPF_UNBUILT" ]; then
         LIBBPF_LDLIBS="-Xlinker --unresolved-symbols=ignore-in-object-files"
         LIBBPF_CFLAGS="-I$TMPDIR/include"
-        mkdir -p "$TMPDIR/include/bpf"
+        mkdir -p "$TMPDIR/include"
+        cp -r headers/bpf headers/linux headers/xdp "$TMPDIR/include/"
         cp "$LIBBPF_DIR"/src/bpf.h "$LIBBPF_DIR"/src/btf.h "$LIBBPF_DIR"/src/libbpf*.h "$TMPDIR/include/bpf"
         [ "$?" -eq 0 ] || return
     fi


### PR DESCRIPTION
…pf features

When the xdp-tools repository is embedded into another module as a git subrepository, we support building against a custom libbpf version. In this case, we still run the feature tests, but we weren't copying over the kernel header files, which can cause some of the libbpf feature tests to fail if the system kernel headers are outdated. This in turn leads to subsequent build errors when trying to build against libbpf (because the build then uses the compatibility functions, leading to conflicts).

Fix this by also copying all the embedded kernel header files into the temporary include directory when running the feature tests and LIBBPF_UNBUILT is set.