### PR TITLE
xdp-loader/README: Mention lack of support for HW mode in most cards

### DIFF
--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -54,7 +54,9 @@ the program to be offloaded to the hardware, or 'unspecified' which leaves it up
 to the kernel to pick a mode (which it will do by picking native mode if the
 driver supports it, or generic mode otherwise). Note that using 'unspecified'
 can make it difficult to predict what mode a program will end up being loaded
-in. For this reason, the default is 'native'.
+in. For this reason, the default is 'native'. Note that hardware with support
+for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
+only devices with support for this in the mainline Linux kernel.
 
 ** -p, --pin-path <path>
 This specifies a root path under which to pin any maps that define the 'pinning'

--- a/xdp-loader/xdp-loader.8
+++ b/xdp-loader/xdp-loader.8
@@ -1,4 +1,4 @@
-.TH "xdp-loader" "8" "AUGUST  9, 2022" "V1.2.2" "XDP program loader"
+.TH "xdp-loader" "8" "NOVEMBER 29, 2022" "V1.2.2" "XDP program loader" 
 
 .SH "NAME"
 xdp-loader \- an XDP program loader
@@ -59,7 +59,9 @@ the program to be offloaded to the hardware, or 'unspecified' which leaves it up
 to the kernel to pick a mode (which it will do by picking native mode if the
 driver supports it, or generic mode otherwise). Note that using 'unspecified'
 can make it difficult to predict what mode a program will end up being loaded
-in. For this reason, the default is 'native'.
+in. For this reason, the default is 'native'. Note that hardware with support
+for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
+only devices with support for this in the mainline Linux kernel.
 
 .SS "-p, --pin-path <path>"
 .PP


### PR DESCRIPTION
We don't document that the 'hw' mode is unsupported on most hardware. Add a
note to the man page explaining this.

Fixes #170