### PR TITLE
libxdp: Fix check in xdp_program__attach_single()

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1532,7 +1532,7 @@ static int xdp_program__attach_single(struct xdp_program *prog, int ifindex,
 {
 	int err;
 
-	if (prog->bpf_obj) {
+	if (prog->prog_fd < 0) {
 		bpf_program__set_type(prog->bpf_prog, BPF_PROG_TYPE_XDP);
 		err = xdp_program__load(prog);
 		if (err)


### PR DESCRIPTION
The check added to xdp_program__attach_single() in an earlier patch was
wrong: the bpf object survives after loading a program. Instead, check if
the fd has already been set and use that as an indicator for whether we
should load the program before attaching.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>