### PR TITLE
configure: Try to auto-detect versioned clang binaries

### DIFF
--- a/configure
+++ b/configure
@@ -23,6 +23,34 @@ check_opts()
     echo "BPF_TARGET:=${BPF_TARGET}" >>$CONFIG
 }
 
+find_tool()
+{
+    local tool_name
+    local tool_path
+    local v
+
+    tool_name="$1"
+    tool_path="$2"
+
+    if [ "$tool_name" != "$tool_path" ] || command -v "$tool_path" >/dev/null 2>&1; then
+        echo $tool_path
+        return 0
+    fi
+
+    # we're looking for a binary with the same name as tool_name; try version
+    # suffixes in order until we find one
+    for v in 16 15 14 13 12 11 10; do
+        tool_path="${tool_name}-$v"
+        if command -v "$tool_path" >/dev/null 2>&1; then
+            echo $tool_path
+            return 0
+        fi
+    done
+
+    # Fall back to supplied default, check in caller will error out
+    echo $tool_name
+}
+
 check_toolchain()
 {
     local emacs_version
@@ -38,6 +66,9 @@ check_toolchain()
     : ${EMACS=emacs}
     : ${ARCH_INCLUDES=}
 
+    CLANG=$(find_tool clang "$CLANG")
+    LLC=$(find_tool llc "$LLC")
+
     for TOOL in $PKG_CONFIG $CC $LD $OBJCOPY $CLANG $LLC $M4; do
         if [ ! $(command -v ${TOOL} 2>/dev/null) ]; then
             echo "*** ERROR: Cannot find tool ${TOOL}" ;
@@ -46,6 +77,11 @@ check_toolchain()
     done
 
     clang_version=$($CLANG --version | grep -Po '(?<=clang version )[[:digit:]]+')
+    if [ "$?" -ne "0" ]; then
+        echo "*** ERROR: Couldn't execute '$CLANG --version'"
+        exit 1
+    fi
+
     echo "Found clang binary '$CLANG' with version $clang_version (from '$($CLANG --version | head -n 1)')"
     if [ "$clang_version" -lt "10" ]; then
         echo "*** ERROR: Need LLVM version 10+, '$CLANG' is version $clang_version"


### PR DESCRIPTION
The clang and llc binaries can be installed as versioned binaries named as
clang-$VERSION. In particular this happens when using the Debian and Ubuntu
packages from the apt.llvm.org repository. To make installation a bit
friendlier, teach the configure script to autodetect such binaries, by
trying each one in order from the newest (clang-16, llc-16) to the
oldest (clang-10, llc-10). We only do this if no explicit path is supplied
in the environment, and only if the non-versioned binary doesn't exist.
I.e., the objective here is to only do autodetection in cases where we
would otherwise fail configure because no binary was found.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>