### PR TITLE
.github/workflows: Update covscan tooling to clang-11

### DIFF
--- a/.github/workflows/covscan.yml
+++ b/.github/workflows/covscan.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Prepare Clang
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" | sudo tee -a /etc/apt/sources.list
+          echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get -qq update
-          sudo apt-get -qq -y install clang-10 lld-10 llvm-10
+          sudo apt-get -qq -y install clang-11 lld-11 llvm-11
 
       - name: Download Coverity Build Tool
         run: |
@@ -37,8 +37,8 @@ jobs:
       - name: Configure
         run: ./configure
         env:
-          CLANG: clang-10
-          LLC: llc-10
+          CLANG: clang-11
+          LLC: llc-11
 
       - name: Build with cov-build
         run: |

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -87,7 +87,8 @@ static inline bool libxdp_validate_opts(const char *opts,
 		pr_warn("%s size (%zu) is too small\n", type_name, user_sz);
 		return false;
 	}
-	if (!libxdp_is_mem_zeroed(opts + opts_sz, (ssize_t)user_sz - opts_sz)) {
+	if (user_sz > opts_sz &&
+	    !libxdp_is_mem_zeroed(opts + opts_sz, (ssize_t)user_sz - opts_sz)) {
 		pr_warn("%s has non-zero extra bytes\n", type_name);
 		return false;
 	}

--- a/lib/util/stats.c
+++ b/lib/util/stats.c
@@ -173,7 +173,7 @@ out:
 
 static int map_collect(int fd, __u32 map_type, __u32 key, struct record *rec)
 {
-	struct datarec value;
+	struct datarec value = {};
 	int err;
 
 	/* Get time as close as possible to reading map contents */

--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -248,6 +248,9 @@ static struct datarec *alloc_records(int nr_entries)
 {
 	struct datarec *array;
 
+	if (nr_entries <= 0)
+		return NULL;
+
 	array = calloc(nr_entries, sizeof(*array));
 	if (!array) {
 		pr_warn("Failed to allocate memory (nr_entries: %u)\n", nr_entries);
@@ -1188,7 +1191,7 @@ static int get_num_rxqs(const char *ifname)
 	};
 	int fd, ret;
 
-	if (!ifname)
+	if (!ifname || strlen(ifname) > sizeof(ifr.ifr_name) - 1)
 		return 0;
 
 	strcpy(ifr.ifr_name, ifname);


### PR DESCRIPTION
Now that we require clang-11 to build, the covscan CI action fails. Update to the llvm-11 for this action as well.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>