### PR TITLE
xdp-loader: Support setting pri/act at runtime.

### DIFF
--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -77,6 +77,19 @@ file. The default is to use the first program in each file. Only one of
 --section and --prog-name may be specified. If this option is set, it applies to
 all programs being loaded.
 
+** -P, --prio <priority>
+Specify the priority to load the XDP program(s) with (this affects the order of
+programs running on the interface). The default is to use the value from the metadata
+in the program ELF file, or a value of 50 if the program has no such metadata.
+If this option is set, it applies to all programs being loaded.
+
+** -A, --actions <actions>
+Specify the "chain call actions" of the loaded XDP program(s). These are the XDP
+actions that will cause the next program loaded on the interface to be called,
+instead of returning immediately. The default is to use the value set in the metadata
+in the program ELF file, or XDP_PASS if no such metadata is set. If this option is set,
+it applies to all programs being loaded.
+
 ** -v, --verbose
 Enable debug logging. Specify twice for even more verbosity.
 


### PR DESCRIPTION
Support passing run priority and chain call actions at runtime, instead of using the static prio/actions in the ELF file. With these options, we can change the prio/actions as we want and no need to change the code and recompile them to ELF file.

Signed-off-by: Dongdong Wang <wangdongdong.6@bytedance.com>