### PR TITLE
Fix building xdp-bench against old libbpf versions

### DIFF
--- a/configure
+++ b/configure
@@ -276,6 +276,7 @@ check_libbpf_functions()
     check_libbpf_function "bpf_map_create" "(0, NULL, 0, 0, 0, NULL)" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "perf_buffer__new_raw" "(0, 0, NULL, NULL, NULL, NULL)" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_xdp_attach" "(0, 0, 0, NULL)" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
+    check_libbpf_function "bpf_map__set_autocreate" "(NULL, false)" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
 }
 
 get_libbpf_version()

--- a/xdp-bench/xdp_redirect_devmap.c
+++ b/xdp-bench/xdp_redirect_devmap.c
@@ -76,10 +76,18 @@ restart:
 
 	if (tried) {
 		tx_port_map = skel->maps.tx_port_general;
-		bpf_map__set_autocreate(skel->maps.tx_port_native, false);
 		bpf_program__set_autoload(skel->progs.xdp_redirect_devmap_egress, false);
+#ifdef HAVE_LIBBPF_BPF_MAP__SET_AUTOCREATE
+		bpf_map__set_autocreate(skel->maps.tx_port_native, false);
+#else
+		pr_warn("Libbpf is missing bpf_map__set_autocreate(), fallback won't work\n");
+		ret = EXIT_FAIL_BPF;
+		goto end_destroy;
+#endif
 	} else {
+#ifdef HAVE_LIBBPF_BPF_MAP__SET_AUTOCREATE
 		bpf_map__set_autocreate(skel->maps.tx_port_general, false);
+#endif
 		tx_port_map = skel->maps.tx_port_native;
 	}
 

--- a/xdp-bench/xdp_redirect_devmap.c
+++ b/xdp-bench/xdp_redirect_devmap.c
@@ -127,6 +127,7 @@ restart:
 			xdp_program__close(xdp_prog);
 			xdp_redirect_devmap__destroy(skel);
 			sample_teardown();
+			xdp_prog = NULL;
 			goto restart;
 		}
 		pr_warn("Failed to attach XDP program: %s\n",

--- a/xdp-bench/xdp_redirect_devmap_multi.c
+++ b/xdp-bench/xdp_redirect_devmap_multi.c
@@ -158,6 +158,7 @@ restart:
 					xdp_program__close(xdp_prog);
 					xdp_redirect_devmap_multi__destroy(skel);
 					sample_teardown();
+					xdp_prog = NULL;
 					goto restart;
 				}
 				pr_warn("Failed to attach XDP program to iface %s: %s\n",

--- a/xdp-bench/xdp_redirect_devmap_multi.c
+++ b/xdp-bench/xdp_redirect_devmap_multi.c
@@ -112,10 +112,18 @@ restart:
 
 	if (tried) {
 		forward_map = skel->maps.forward_map_general;
-		bpf_map__set_autocreate(skel->maps.forward_map_native, false);
 		bpf_program__set_autoload(skel->progs.xdp_devmap_prog, false);
+#ifdef HAVE_LIBBPF_BPF_MAP__SET_AUTOCREATE
+		bpf_map__set_autocreate(skel->maps.forward_map_native, false);
+#else
+		pr_warn("Libbpf is missing bpf_map__set_autocreate(), fallback won't work\n");
+		ret = EXIT_FAIL_BPF;
+		goto end_destroy;
+#endif
 	} else {
+#ifdef HAVE_LIBBPF_BPF_MAP__SET_AUTOCREATE
 		bpf_map__set_autocreate(skel->maps.forward_map_general, false);
+#endif
 		forward_map = skel->maps.forward_map_native;
 	}
 


### PR DESCRIPTION
Add a configuration check to allow xdp-bench to build against old libbpf
versions, and fix a potential double-free error discovered in the process of
doing this.