### PR TITLE
xdp-bench: Add pass action

### DIFF
--- a/xdp-bench/Makefile
+++ b/xdp-bench/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
 XDP_TARGETS := xdp_redirect_basic.bpf xdp_redirect_cpumap.bpf xdp_redirect_devmap.bpf \
-	       xdp_redirect_devmap_multi.bpf xdp_droptx.bpf
+	       xdp_redirect_devmap_multi.bpf xdp_basic.bpf
 BPF_SKEL_TARGETS := $(XDP_TARGETS)
 
 TOOL_NAME := xdp-bench
@@ -10,7 +10,7 @@ TEST_FILE := tests/test-xdp-bench.sh
 USER_TARGETS := xdp-bench
 USER_LIBS     = -lm
 USER_EXTRA_C := xdp_redirect_basic.c xdp_redirect_cpumap.c xdp_redirect_devmap.c \
-		xdp_redirect_devmap_multi.c xdp_droptx.c
+		xdp_redirect_devmap_multi.c xdp_basic.c
 EXTRA_USER_DEPS := xdp-bench.h
 
 LIB_DIR       = ../lib

--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -66,12 +66,72 @@ following actions are available:
 #+begin_src sh
  no-touch		- Drop the packet without touching the packet data
  touch		- Read a field in the packet header before dropping
- swap-macs		- Swap the soruce and destination MAC addresses before dropping
+ swap-macs		- Swap the source and destination MAC addresses before dropping
 #+end_src
 
 Whether to touch the packet before dropping it can have a significant
 performance impact as this requires bringing packet data into the CPU cache (and
 flushing it back out if writing).
+
+The default for this option is =no-touch=.
+
+** -r, --rxq-stats
+If set, the XDP program will also gather statistics on which receive queue index
+each packet was received on. This is displayed in the extended output mode along
+with per-CPU data (which, depending on the hardware configuration may or may not
+be equivalent).
+
+** -i, --interval <SECONDS>
+Set the polling interval for collecting all statistics and displaying them to
+the output. The unit of interval is in seconds.
+
+** -e, --extended
+Start xdp-bench in "extended" output mode. If not set, xdp-bench will start in
+"terse" mode. The output mode can be switched by hitting C-\ while the program
+is running. See also the *Output Format Description* section below.
+
+** -m, --mode
+Selects the XDP program mode (native or skb). Note that native XDP mode is the
+default, and loading the redirect program in skb manner is neither performant,
+nor recommended. However, this option is useful if the interface driver lacks
+native XDP support, or when simply testing the tool.
+
+** -v, --verbose
+Enable verbose logging. Supply twice to enable verbose logging from the
+underlying =libxdp= and =libbpf= libraries.
+
+** --version
+Show the application version and exit.
+
+** -h, --help
+Display a summary of the available options
+
+* The PASS command
+In this mode, =xdp-bench= installs an XDP program on an interface that passes
+all packets to the network stack after processing them (returning =XDP_PASS=).
+There are options to control what to do with the packet before passing it
+(touch the packet data or not), as well as which statistics to gather. This is a
+basic benchmark for the overhead of installing an XDP program on an interface
+while still running the regular network stack.
+
+The syntax for the =pass= command is:
+
+=xdp-bench pass [options] <ifname>=
+
+Where =<ifname>= is the name of the interface the XDP program should be
+installed on.
+
+The supported options are:
+
+** -p, --packet-operation <ACTION>
+Specify which operation should be taken on the packet before passing it. The
+following actions are available:
+
+#+begin_src sh
+ no-touch		- Pass the packet without touching the packet data
+ touch		- Read a field in the packet header before passing
+ swap-macs		- Swap the source and destination MAC addresses before passing
+#+end_src
 
 The default for this option is =no-touch=.
 
@@ -129,7 +189,7 @@ following actions are available:
 #+begin_src sh
  no-touch		- Transmit the packet without touching the packet data
  touch		- Read a field in the packet header before transmitting
- swap-macs		- Swap the soruce and destination MAC addresses before transmitting
+ swap-macs		- Swap the source and destination MAC addresses before transmitting
 #+end_src
 
 To allow the packet to be successfully transmitted back to the sender, the MAC

--- a/xdp-bench/tests/test-xdp-bench.sh
+++ b/xdp-bench/tests/test-xdp-bench.sh
@@ -1,25 +1,30 @@
 XDP_LOADER=${XDP_LOADER:-./xdp-loader}
 XDP_BENCH=${XDP_BENCH:-./xdp-bench}
-ALL_TESTS="test_drop test_tx test_rxq_stats test_redirect test_redirect_cpu test_redirect_map test_redirect_map_egress test_redirect_multi test_redirect_multi_egress"
+ALL_TESTS="test_drop test_pass test_tx test_rxq_stats test_redirect test_redirect_cpu test_redirect_map test_redirect_map_egress test_redirect_multi test_redirect_multi_egress"
+
+test_basic()
+{
+    action=$1
+
+    export XDP_SAMPLE_IMMEDIATE_EXIT=1
+    check_run $XDP_BENCH $action $NS -vv
+    check_run $XDP_BENCH $action $NS -p read-data -vv
+    check_run $XDP_BENCH $action $NS -p swap-macs -vv
+    check_run $XDP_BENCH $action $NS -m skb -vv
+    check_run $XDP_BENCH $action $NS -e -vv
+}
 
 test_drop()
 {
-    export XDP_SAMPLE_IMMEDIATE_EXIT=1
-    check_run $XDP_BENCH drop $NS -vv
-    check_run $XDP_BENCH drop $NS -p read-data -vv
-    check_run $XDP_BENCH drop $NS -p swap-macs -vv
-    check_run $XDP_BENCH drop $NS -m skb -vv
-    check_run $XDP_BENCH drop $NS -e -vv
+    test_basic drop
 }
-
+test_pass()
+{
+    test_basic pass
+}
 test_tx()
 {
-    export XDP_SAMPLE_IMMEDIATE_EXIT=1
-    check_run $XDP_BENCH tx $NS -vv
-    check_run $XDP_BENCH tx $NS -p read-data -vv
-    check_run $XDP_BENCH tx $NS -p swap-macs -vv
-    check_run $XDP_BENCH tx $NS -m skb -vv
-    check_run $XDP_BENCH tx $NS -e -vv
+    test_basic tx
 }
 
 test_rxq_stats()

--- a/xdp-bench/xdp-bench.8
+++ b/xdp-bench/xdp-bench.8
@@ -1,4 +1,4 @@
-.TH "xdp-bench" "8" "DECEMBER  9, 2022" "V1.2.2" "A simple XDP benchmarking tool" 
+.TH "xdp-bench" "8" "JANUARY  6, 2023" "V1.2.2" "A simple XDP benchmarking tool" 
 
 .SH "NAME"
 XDP-bench \- a XDP simple benchmarking tool
@@ -75,7 +75,7 @@ following actions are available:
 .nf
 \fCno-touch		- Drop the packet without touching the packet data
 touch		- Read a field in the packet header before dropping
-swap-macs		- Swap the soruce and destination MAC addresses before dropping
+swap-macs		- Swap the source and destination MAC addresses before dropping
 \fP
 .fi
 .RE
@@ -84,6 +84,83 @@ swap-macs		- Swap the soruce and destination MAC addresses before dropping
 Whether to touch the packet before dropping it can have a significant
 performance impact as this requires bringing packet data into the CPU cache (and
 flushing it back out if writing).
+
+.PP
+The default for this option is \fIno\-touch\fP.
+
+.SS "-r, --rxq-stats"
+.PP
+If set, the XDP program will also gather statistics on which receive queue index
+each packet was received on. This is displayed in the extended output mode along
+with per-CPU data (which, depending on the hardware configuration may or may not
+be equivalent).
+
+.SS "-i, --interval <SECONDS>"
+.PP
+Set the polling interval for collecting all statistics and displaying them to
+the output. The unit of interval is in seconds.
+
+.SS "-e, --extended"
+.PP
+Start xdp-bench in "extended" output mode. If not set, xdp-bench will start in
+"terse" mode. The output mode can be switched by hitting C-$\ while the program
+is running. See also the \fBOutput Format Description\fP section below.
+
+.SS "-m, --mode"
+.PP
+Selects the XDP program mode (native or skb). Note that native XDP mode is the
+default, and loading the redirect program in skb manner is neither performant,
+nor recommended. However, this option is useful if the interface driver lacks
+native XDP support, or when simply testing the tool.
+
+.SS "-v, --verbose"
+.PP
+Enable verbose logging. Supply twice to enable verbose logging from the
+underlying \fIlibxdp\fP and \fIlibbpf\fP libraries.
+
+.SS "--version"
+.PP
+Show the application version and exit.
+
+.SS "-h, --help"
+.PP
+Display a summary of the available options
+
+.SH "The PASS command"
+.PP
+In this mode, \fIxdp\-bench\fP installs an XDP program on an interface that passes
+all packets to the network stack after processing them (returning \fIXDP_PASS\fP).
+There are options to control what to do with the packet before passing it
+(touch the packet data or not), as well as which statistics to gather. This is a
+basic benchmark for the overhead of installing an XDP program on an interface
+while still running the regular network stack.
+
+.PP
+The syntax for the \fIpass\fP command is:
+
+.PP
+\fIxdp\-bench pass [options] <ifname>\fP
+
+.PP
+Where \fI<ifname>\fP is the name of the interface the XDP program should be
+installed on.
+
+.PP
+The supported options are:
+
+.SS "-p, --packet-operation <ACTION>"
+.PP
+Specify which operation should be taken on the packet before passing it. The
+following actions are available:
+
+.RS
+.nf
+\fCno-touch		- Pass the packet without touching the packet data
+touch		- Read a field in the packet header before passing
+swap-macs		- Swap the source and destination MAC addresses before passing
+\fP
+.fi
+.RE
 
 .PP
 The default for this option is \fIno\-touch\fP.
@@ -156,7 +233,7 @@ following actions are available:
 .nf
 \fCno-touch		- Transmit the packet without touching the packet data
 touch		- Read a field in the packet header before transmitting
-swap-macs		- Swap the soruce and destination MAC addresses before transmitting
+swap-macs		- Swap the source and destination MAC addresses before transmitting
 \fP
 .fi
 .RE

--- a/xdp-bench/xdp-bench.c
+++ b/xdp-bench/xdp-bench.c
@@ -15,6 +15,7 @@ int do_help(__unused const void *cfg, __unused const char *pin_root_path)
 		"\n"
 		"COMMAND can be one of:\n"
 		"       drop           - Drop all packets on an interface\n"
+		"       pass           - Pass all packets to the network stack\n"
 		"       tx             - Transmit packets back out on an interface (hairpin forwarding)\n"
 		"       redirect       - XDP redirect using the bpf_redirect() helper\n"
 		"       redirect-cpu   - XDP CPU redirect using BPF_MAP_TYPE_CPUMAP\n"
@@ -33,10 +34,10 @@ struct enum_val xdp_modes[] = {
        {NULL, 0}
 };
 
-struct enum_val droptx_program_modes[] = {
-       {"no-touch", DROPTX_NO_TOUCH},
-       {"read-data", DROPTX_READ_DATA},
-       {"swap-macs", DROPTX_SWAP_MACS},
+struct enum_val basic_program_modes[] = {
+       {"no-touch", BASIC_NO_TOUCH},
+       {"read-data", BASIC_READ_DATA},
+       {"swap-macs", BASIC_SWAP_MACS},
        {NULL, 0}
 };
 
@@ -59,28 +60,28 @@ struct enum_val cpumap_program_modes[] = {
 };
 
 
-struct prog_option droptx_options[] = {
-	DEFINE_OPTION("program-mode", OPT_ENUM, struct droptx_opts, program_mode,
+struct prog_option basic_options[] = {
+	DEFINE_OPTION("program-mode", OPT_ENUM, struct basic_opts, program_mode,
 		      .short_opt = 'p',
 		      .metavar = "<mode>",
-		      .typearg = droptx_program_modes,
+		      .typearg = basic_program_modes,
 		      .help = "Action to take before dropping packet."),
-	DEFINE_OPTION("rxq-stats", OPT_BOOL, struct droptx_opts, rxq_stats,
+	DEFINE_OPTION("rxq-stats", OPT_BOOL, struct basic_opts, rxq_stats,
 		      .short_opt = 'r',
 		      .help = "Collect per-RXQ drop statistics"),
-	DEFINE_OPTION("interval", OPT_U32, struct droptx_opts, interval,
+	DEFINE_OPTION("interval", OPT_U32, struct basic_opts, interval,
 		      .short_opt = 'i',
 		      .metavar = "<seconds>",
 		      .help = "Polling interval (default 2)"),
-	DEFINE_OPTION("extended", OPT_BOOL, struct droptx_opts, extended,
+	DEFINE_OPTION("extended", OPT_BOOL, struct basic_opts, extended,
 		      .short_opt = 'e',
 		      .help = "Start running in extended output mode (C^\\ to toggle)"),
-	DEFINE_OPTION("xdp-mode", OPT_ENUM, struct droptx_opts, mode,
+	DEFINE_OPTION("xdp-mode", OPT_ENUM, struct basic_opts, mode,
 		      .short_opt = 'm',
 		      .typearg = xdp_modes,
 		      .metavar = "<mode>",
 		      .help = "Load XDP program in <mode>; default native"),
-	DEFINE_OPTION("dev", OPT_IFNAME, struct droptx_opts, iface_in,
+	DEFINE_OPTION("dev", OPT_IFNAME, struct basic_opts, iface_in,
 		      .positional = true,
 		      .metavar = "<ifname>",
 		      .required = true,
@@ -89,27 +90,27 @@ struct prog_option droptx_options[] = {
 };
 
 struct prog_option redirect_basic_options[] = {
-	DEFINE_OPTION("interval", OPT_U32, struct basic_opts, interval,
+	DEFINE_OPTION("interval", OPT_U32, struct redirect_opts, interval,
 		      .short_opt = 'i',
 		      .metavar = "<seconds>",
 		      .help = "Polling interval (default 2)"),
-	DEFINE_OPTION("stats", OPT_BOOL, struct basic_opts, stats,
+	DEFINE_OPTION("stats", OPT_BOOL, struct redirect_opts, stats,
 		      .short_opt = 's',
 		      .help = "Enable statistics for transmitted packets (not just errors)"),
-	DEFINE_OPTION("extended", OPT_BOOL, struct basic_opts, extended,
+	DEFINE_OPTION("extended", OPT_BOOL, struct redirect_opts, extended,
 		      .short_opt = 'e',
 		      .help = "Start running in extended output mode (C^\\ to toggle)"),
-	DEFINE_OPTION("mode", OPT_ENUM, struct basic_opts, mode,
+	DEFINE_OPTION("mode", OPT_ENUM, struct redirect_opts, mode,
 		      .short_opt = 'm',
 		      .typearg = xdp_modes,
 		      .metavar = "<mode>",
 		      .help = "Load XDP program in <mode>; default native"),
-	DEFINE_OPTION("dev_in", OPT_IFNAME, struct basic_opts, iface_in,
+	DEFINE_OPTION("dev_in", OPT_IFNAME, struct redirect_opts, iface_in,
 		      .positional = true,
 		      .metavar = "<ifname_in>",
 		      .required = true,
 		      .help = "Redirect from device <ifname>"),
-	DEFINE_OPTION("dev_out", OPT_IFNAME, struct basic_opts, iface_out,
+	DEFINE_OPTION("dev_out", OPT_IFNAME, struct redirect_opts, iface_out,
 		      .positional = true,
 		      .metavar = "<ifname_out>",
 		      .required = true,
@@ -231,12 +232,17 @@ struct prog_option redirect_devmap_multi_options[] = {
 static const struct prog_command cmds[] = {
 	{ .name = "drop",
 	  .func = do_drop,
-	  .options = droptx_options,
+	  .options = basic_options,
 	  .default_cfg = &defaults_drop,
 	  .doc = "Drop all packets on an interface" },
+	{ .name = "pass",
+	  .func = do_pass,
+	  .options = basic_options,
+	  .default_cfg = &defaults_pass,
+	  .doc = "Pass all packets to the network stack" },
 	{ .name = "tx",
 	  .func = do_tx,
-	  .options = droptx_options,
+	  .options = basic_options,
 	  .default_cfg = &defaults_tx,
 	  .doc = "Transmit packets back out an interface (hairpin forwarding)" },
 	DEFINE_COMMAND_NAME("redirect", redirect_basic,

--- a/xdp-bench/xdp-bench.h
+++ b/xdp-bench/xdp-bench.h
@@ -9,28 +9,29 @@
 #define MAX_IFACE_NUM 32
 
 int do_drop(const void *cfg, const char *pin_root_path);
+int do_pass(const void *cfg, const char *pin_root_path);
 int do_tx(const void *cfg, const char *pin_root_path);
 int do_redirect_basic(const void *cfg, const char *pin_root_path);
 int do_redirect_cpumap(const void *cfg, const char *pin_root_path);
 int do_redirect_devmap(const void *cfg, const char *pin_root_path);
 int do_redirect_devmap_multi(const void *cfg, const char *pin_root_path);
 
-enum droptx_program_mode {
-	DROPTX_NO_TOUCH,
-	DROPTX_READ_DATA,
-	DROPTX_SWAP_MACS,
+enum basic_program_mode {
+	BASIC_NO_TOUCH,
+	BASIC_READ_DATA,
+	BASIC_SWAP_MACS,
 };
 
-struct droptx_opts {
+struct basic_opts {
 	bool extended;
 	bool rxq_stats;
 	__u32 interval;
 	enum xdp_attach_mode mode;
-	enum droptx_program_mode program_mode;
+	enum basic_program_mode program_mode;
 	struct iface iface_in;
 };
 
-struct basic_opts {
+struct redirect_opts {
 	bool stats;
 	bool extended;
 	__u32 interval;
@@ -88,9 +89,10 @@ struct cpumap_opts {
 	struct iface redir_iface;
 };
 
-extern const struct droptx_opts defaults_drop;
-extern const struct droptx_opts defaults_tx;
-extern const struct basic_opts defaults_redirect_basic;
+extern const struct basic_opts defaults_drop;
+extern const struct basic_opts defaults_pass;
+extern const struct basic_opts defaults_tx;
+extern const struct redirect_opts defaults_redirect_basic;
 extern const struct cpumap_opts defaults_redirect_cpumap;
 extern const struct devmap_opts defaults_redirect_devmap;
 extern const struct devmap_multi_opts defaults_redirect_devmap_multi;

--- a/xdp-bench/xdp_basic.bpf.c
+++ b/xdp-bench/xdp_basic.bpf.c
@@ -21,7 +21,7 @@ const volatile bool rxq_stats = 0;
 const volatile enum xdp_action action = XDP_DROP;
 
 SEC("xdp")
-int xdp_droptx_prog(struct xdp_md *ctx)
+int xdp_basic_prog(struct xdp_md *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;
 	void *data = (void *)(long)ctx->data;

--- a/xdp-bench/xdp_redirect_basic.c
+++ b/xdp-bench/xdp_redirect_basic.c
@@ -30,12 +30,12 @@ static int mask = SAMPLE_RX_CNT | SAMPLE_REDIRECT_ERR_CNT |
 
 DEFINE_SAMPLE_INIT(xdp_redirect_basic);
 
-const struct basic_opts defaults_redirect_basic = { .mode = XDP_MODE_NATIVE,
+const struct redirect_opts defaults_redirect_basic = { .mode = XDP_MODE_NATIVE,
 						    .interval = 2 };
 
 int do_redirect_basic(const void *cfg, __unused const char *pin_root_path)
 {
-	const struct basic_opts *opt = cfg;
+	const struct redirect_opts *opt = cfg;
 
 	struct xdp_program *xdp_prog = NULL, *dummy_prog = NULL;
 	DECLARE_LIBBPF_OPTS(xdp_program_opts, opts);


### PR DESCRIPTION
It seemed odd to not support XDP_PASS in xdp-bench, so add a 'pass' action
as well, reusing the same code as 'drop' and 'tx', which is already
identical apart from the return code. Rename 'droptx' to 'basic' everywhere
in the code to support this.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>