### PR TITLE
libxdp: Add support for loading programs with frags support

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -88,6 +88,9 @@ int xdp_program__set_chain_call_enabled(struct xdp_program *prog,
 int xdp_program__print_chain_call_actions(const struct xdp_program *prog,
 					  char *buf,
 					  size_t buf_len);
+bool xdp_program__xdp_frags_support(const struct xdp_program *prog);
+int xdp_program__set_xdp_frags_support(struct xdp_program *prog, bool frags);
+
 int xdp_program__pin(struct xdp_program *xdp_prog, const char *pin_path);
 int xdp_program__attach(struct xdp_program *xdp_prog,
 			int ifindex, enum xdp_attach_mode mode,
@@ -112,6 +115,7 @@ struct xdp_program *xdp_multiprog__main_prog(const struct xdp_multiprog *mp);
 struct xdp_program *xdp_multiprog__hw_prog(const struct xdp_multiprog *mp);
 bool xdp_multiprog__is_legacy(const struct xdp_multiprog *mp);
 int xdp_multiprog__program_count(const struct xdp_multiprog *mp);
+bool xdp_multiprog__xdp_frags_support(const struct xdp_multiprog *mp);
 
 /* Only following members can be set at once:
  *

--- a/headers/xdp/prog_dispatcher.h
+++ b/headers/xdp/prog_dispatcher.h
@@ -6,7 +6,10 @@
 #include <linux/types.h>
 
 #define XDP_METADATA_SECTION "xdp_metadata"
-#define XDP_DISPATCHER_VERSION 1
+#define XDP_DISPATCHER_VERSION 2
+
+/* magic byte is 'X' + 'D' + 'P' (88+68+80=236) */
+#define XDP_DISPATCHER_MAGIC 236
 /* default retval for dispatcher corresponds to the highest bit in the
  * chain_call_actions bitmap; we use this to make sure the dispatcher always
  * continues the calls chain if a function does not have an freplace program
@@ -19,9 +22,13 @@
 #endif
 
 struct xdp_dispatcher_config {
-	__u8 num_progs_enabled;
+	__u8 magic;                         /* Set to XDP_DISPATCHER_MAGIC */
+	__u8 dispatcher_version;            /* Set to XDP_DISPATCHER_VERSION */
+	__u8 num_progs_enabled;             /* Number of active program slots */
+	__u8 is_xdp_frags;                  /* Whether this dispatcher is loaded with XDP frags support */
 	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
 	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
+	__u32 program_flags[MAX_DISPATCHER_ACTIONS];
 };
 
 #endif

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -546,8 +546,8 @@ static int do_xdp_attach(int ifindex, int prog_fd, int old_fd, __u32 xdp_flags)
 #endif
 }
 
-static int xdp_attach_fd(int prog_fd, int old_fd, int ifindex,
-			 enum xdp_attach_mode mode)
+int xdp_attach_fd(int prog_fd, int old_fd, int ifindex,
+		  enum xdp_attach_mode mode)
 {
 	int err = 0, xdp_flags = 0;
 

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -69,7 +69,10 @@ LIBXDP_1.2.0 {
 } LIBXDP_1.0.0;
 
 LIBXDP_1.3.0 {
+		xdp_multiprog__xdp_frags_support;
 		xdp_program__clone;
 		xdp_program__create;
+		xdp_program__set_xdp_frags_support;
 		xdp_program__test_run;
+		xdp_program__xdp_frags_support;
 } LIBXDP_1.2.0;

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -45,6 +45,8 @@ LIBXDP_HIDE_SYMBOL __printf(2, 3) void libxdp_print(enum libxdp_print_level leve
 LIBXDP_HIDE_SYMBOL int check_xdp_prog_version(const struct btf *btf, const char *name,
 					      __u32 *version);
 
+LIBXDP_HIDE_SYMBOL int libxdp_check_kern_compat(void);
+
 #define min(x, y) ((x) < (y) ? x : y)
 #define max(x, y) ((x) > (y) ? x : y)
 

--- a/lib/libxdp/libxdp_internal.h
+++ b/lib/libxdp/libxdp_internal.h
@@ -140,5 +140,7 @@ static inline void *libxdp_err_ptr(int err, bool ret_null)
 
 LIBXDP_HIDE_SYMBOL int xdp_lock_acquire(void);
 LIBXDP_HIDE_SYMBOL int xdp_lock_release(int lock_fd);
+LIBXDP_HIDE_SYMBOL int xdp_attach_fd(int prog_fd, int old_fd, int ifindex,
+				     enum xdp_attach_mode mode);
 
 #endif /* __LIBXDP_LIBXDP_INTERNAL_H */

--- a/lib/libxdp/protocol.org
+++ b/lib/libxdp/protocol.org
@@ -28,14 +28,19 @@ the following:
 
 #+begin_src C
 #define XDP_METADATA_SECTION "xdp_metadata"
-#define XDP_DISPATCHER_VERSION 1
+#define XDP_DISPATCHER_VERSION 2
+#define XDP_DISPATCHER_MAGIC 236
 #define XDP_DISPATCHER_RETVAL 31
 #define MAX_DISPATCHER_ACTIONS 10
 
 struct xdp_dispatcher_config {
-	__u8 num_progs_enabled;
+	__u8 magic;                         /* Set to XDP_DISPATCHER_MAGIC */
+	__u8 dispatcher_version;            /* Set to XDP_DISPATCHER_VERSION */
+	__u8 num_progs_enabled;             /* Number of active program slots */
+	__u8 is_xdp_frags;                  /* Whether this dispatcher is loaded with XDP frags support */
 	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
 	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
+	__u32 program_flags[MAX_DISPATCHER_ACTIONS];
 };
 
 /* While 'const volatile' sounds a little like an oxymoron, there's reason
@@ -100,15 +105,26 @@ configuration struct is populated before the object is loaded. As a forward
 compatibility measure, =libxdp= will also check for the presence of the
 =dispatcher_version= field in the =xdp_metadata= section (encoded like the
 program metadata described in "Processing program metadata" below), and if it
-doesn't match the expected version (currently only version 1 exists), will abort
-any action.
+doesn't match the expected version (currently version 2), will abort any action.
 
 
 *** Populating the dispatcher configuration map
 On loading, the dispatcher configuration map is populated as follows:
 
+- The =magic= field is set to the =XDP_DISPATCHER_MAGIC= value (236). This field
+  is here to make it possible to check if a program is a dispatcher without
+  looking at the program BTF in the future.
+
+- The =dispatcher_version= field is set to the current dispatcher version (2).
+  This is redundant with the BTF-encoded version in the metadata field, but must
+  be checked so that the BTF metadata version can be removed in the future. See
+  the section on old dispatcher versions below.
+
 - The =num_progs_enabled= member is simply set to the number of active programs
   that will be attached to this dispatcher.
+
+- The =is_xdp_frags= variable is set to 1 if dispatcher is loaded with XDP frags
+  support (see section below), or 0 otherwise.
 
 The two other fields contain per-component program metadata, which is read from
 the component programs as explained in the "Processing program metadata" section
@@ -131,6 +147,11 @@ below.
   the configuration array so it can be carried forward when the dispatcher is
   replaced. Component programs are expected to be sorted in order of their run
   priority (as explained below in "Loading and attaching component programs").
+
+- The =program_flags= is used to store the flags that an XDP program was loaded
+  with. This is populated with the value of the =BPF_F_XDP_HAS_FRAGS= flag if
+  the component program in this slot had that flag set (see the section on XDP
+  frags support below), and is 0 otherwise.
 
 **** Processing program metadata
 As explained above, each component program must specify one or more chain call
@@ -192,12 +213,44 @@ runtime. These overridden values will be the ones used when determining program
 order, and will be preserved in the dispatcher configuration map for subsequent
 operations.
 
+*** Old versions of the XDP dispatcher
+This document currently describes version 2 of the dispatcher and protocol. This
+differs from version 1 in the following respects:
+
+- The dispatcher configuration map has gained the =magic= and
+  =dispatcher_version= fields for identifying the dispatcher and its version..
+
+- The protocol now supports propagating the value of the =BPF_F_XDP_HAS_FRAGS=
+  field for supporting XDP frags programs for higher MTU. The dispatcher
+  configuration map has gained the =is_xdp_frags= and =program_flags= fields for
+  use with this feature. The protocol for propagating the frags field is
+  described below, and an implementation of this protocol that recognises
+  version 2 of the dispatcher MUST implement this protocol.
+
+Older versions of libxdp will check the dispatcher version field of any
+dispatcher loaded in the kernel, and refuse to operate on a dispatcher with a
+higher version than the library version implements. This means that if a newer
+dispatcher is loaded, old versions of the library will be locked out of
+modifying that dispatcher. This is by design: old library versions don't
+recognise the semantics of new features added in subsequent versions, and so
+would introduce bugs if it attempted to operate on newer versions.
+
+Newer versions of libxdp will, however, recognise older dispatcher versions. If
+a newer version of libxdp loads a new program and finds an old dispatcher
+version already loaded on an interface, it will display the programs attached to
+it, but will refuse to replace it with a newer version so as not to lock out the
+program that loaded the program(s) already attached. Manually unloading the
+loaded programs will be required to load a new dispatcher version on the
+interface.
+
 *** Loading and attaching component programs
 When loading one or more XDP programs onto an interface (assuming no existing
 program is found on the interface; for adding programs, see below), =libxdp=
 first prepares a dispatcher program with the right number of slots, by
 populating the configuration struct as described above. Then, this dispatcher
-program is loaded into the kernel.
+program is loaded into the kernel, with the =BPF_F_XDP_HAS_FRAGS= flag set if
+all component programs have that flag set (see the section on supporting XDP
+frags below).
 
 Having loaded the dispatcher program, =libxdp= then loads each of the component
 programs. To do this, first the list of component programs is sorted by their
@@ -212,7 +265,8 @@ deterministic, order (see =cmp_xdp_programs()= [[https://github.com/xdp-project/
 - By load time
 
 Before loading, each component program type is reset to =BPF_PROG_TYPE_EXT= with
-an expected attach type of 0. Then, the attachment target is set to the
+an expected attach type of 0, and the =BPF_F_XDP_HAS_FRAGS= is unset (see the
+section on supporting frags below). Then, the attachment target is set to the
 dispatcher file descriptor and the BTF ID of the stub function to replace (i.e.,
 the first component program has =prog0()= as its target, and so on). Then the
 program is loaded, at which point the kernel will verify the component program's
@@ -261,6 +315,60 @@ flag is set to prevent accidentally overriding any concurrent modifications. If
 this fails, the whole operation starts over, turning the load into a
 modification as described below.
 
+*** Supporting XDP programs with frags support (BPF_F_XDP_HAS_FRAGS flag)
+Linux kernel 5.18 added support for a new API that allows XDP programs to access
+packet data that spans more than a single page, allowing XDP programs to be
+loaded on interfaces with bigger MTUs. Such packets will not have all their
+packet data accessible by the traditional "direct packet access"; instead, only
+the first fragment will be available this way, and the rest of the packet data
+has to be accessed via the new =bpf_xdp_load_bytes()= helper.
+
+Existing XDP programs are written with the assumption that they can see the
+whole packet data using direct packet access, which means they can subtly
+malfunction if some of the packet data is suddenly invisible (for instance,
+counting packet lengths is no longer accurate). Whether a given XDP program
+supports the frags API or not is a semantic issue, and it's not possible for the
+kernel to auto-detect this. For this reason, programs have to opt in to XDP
+frags support at load time, by setting the =BPF_F_XDP_HAS_FRAGS= flag as they
+are loaded into the kernel. Programs that are not loaded with this flag will be
+rejected from attaching to network devices that use packet fragment (i.e., those
+with a large MTU).
+
+This has implications for the XDP dispatcher, as its purpose is for multiple
+programs to be loaded at the same time. Since the =BPF_F_XDP_HAS_FRAGS= cannot
+be set for individual component programs, it has to be set for the dispatcher as
+a whole. However, as described above, programs can subtly malfunction if they
+are exposed to packets with fragments without being ready to do so. This means
+that it's only safe to set the =BPF_F_XDP_HAS_FRAGS= on the dispatcher itself if
+*all* component programs have the flag set.
+
+To properly propagate the flags even when adding new programs to an existing
+dispatcher, the dispatcher itself needs to keep track of which of its component
+programs had the =BPF_F_XDP_HAS_FRAGS= flag set when they were added. The
+dispatcher configuration map users the =program_flags= array for this: for each
+component program, this field is set to the value of the =BPF_F_XDP_HAS_FRAGS=
+flag if that component program has the flag set, and to 0 otherwise. An
+additional field, =is_xdp_frags=, is set if the dispatcher itself is loaded with
+the frags field set (which may not be the case if the kernel doesn't support the
+flag).
+
+When generating a dispatcher for a set of programs, libxdp simply tracks if all
+component programs support the =BPF_F_XDP_HAS_FRAGS=, and if they do, the
+dispatcher is loaded with this flag set. If any program attached to the
+dispatcher does not support the flag, the dispatcher is loaded without this flag
+set (and the =is_xdp_frags= field in the dispatcher configuration is set
+accordingly). If libxdp determines that the running kernel does not support the
+=BPF_F_XDP_HAS_FRAGS=, the dispatcher is loaded without the flag regardless of
+the value of the component programs.
+
+When adding a program to an existing dispatcher, this may result in a
+"downgrade", i.e., loading a new dispatcher without the frags flag to replace an
+existing dispatcher that does have the flag set. This will result in the
+replacement dispatcher being rejected by the kernel at attach time, but only if
+the interface being attached to actually requires the frags flag (i.e., if it
+has a large MTU). If the attachment is rejected, the old dispatcher will stay in
+place, leading to no loss of functionality.
+
 ** Adding or removing programs from an existing dispatcher
 The sections above explain how to generate a dispatcher and attach it to an
 interface, assuming no existing program is attached. When one or more programs
@@ -306,7 +414,10 @@ populating the component program structure in memory, the chain call actions and
 run priority from the dispatcher configuration map is used instead of parsing
 the BTF metadata of each program: This ensures that any modified values
 specified at load time will be retained in stead of being reverted to the
-values compiled into the BTF metadata.
+values compiled into the BTF metadata. Similarly, the =program_flags= array of
+the in-kernel dispatcher is used to determine which of the existing component
+programs support the =BPF_F_XDP_HAS_FRAGS= flag (see the section on frags
+support above).
 
 *** Generating a new dispatcher
 Having obtained a reference to the existing dispatcher, =libxdp= takes that and

--- a/lib/libxdp/tests/.gitignore
+++ b/lib/libxdp/tests/.gitignore
@@ -1,0 +1,2 @@
+test_xsk_refcnt
+check_kern_compat

--- a/lib/libxdp/tests/.gitignore
+++ b/lib/libxdp/tests/.gitignore
@@ -1,2 +1,3 @@
 test_xsk_refcnt
 check_kern_compat
+test_xdp_frags

--- a/lib/libxdp/tests/.gitignore
+++ b/lib/libxdp/tests/.gitignore
@@ -1,3 +1,4 @@
 test_xsk_refcnt
 check_kern_compat
 test_xdp_frags
+test_dispatcher_versions

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt check_kern_compat
+USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags
 USER_LIBS := -lpthread
 
 EXTRA_DEPS +=

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags
+USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags test_dispatcher_versions
+BPF_TARGETS := xdp_dispatcher_v1 xdp_pass
 USER_LIBS := -lpthread
 
-EXTRA_DEPS +=
+EXTRA_DEPS += xdp_dispatcher_v1.h
 EXTRA_USER_DEPS += test_utils.h
 
 TEST_FILE := ./test-libxdp.sh
@@ -11,6 +12,7 @@ TEST_RUNNER := ./test_runner.sh
 
 USER_C := ${USER_TARGETS:=.c}
 USER_OBJ := ${USER_C:.c=.o}
+BPF_OBJS := $(BPF_TARGETS:=.o)
 
 LIB_DIR := ../..
 LDLIBS += $(USER_LIBS)
@@ -37,7 +39,7 @@ CFLAGS += -I$(HEADER_DIR)
 
 BPF_HEADERS := $(wildcard $(HEADER_DIR)/bpf/*.h) $(wildcard $(HEADER_DIR)/xdp/*.h)
 
-all: $(USER_TARGETS)
+all: $(USER_TARGETS) $(BPF_OBJS)
 
 .PHONY: clean
 clean::
@@ -61,5 +63,18 @@ $(ALL_EXEC_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OB
 	$(QUIET_CC)$(CC) -Wall $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(LIB_OBJS) \
 	 $< $(LDLIBS)
 
+$(BPF_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK) $(EXTRA_DEPS)
+	$(QUIET_CLANG)$(CLANG) -S \
+	    -target $(BPF_TARGET) \
+	    -D __BPF_TRACING__ \
+	    $(BPF_CFLAGS) \
+	    -Wall \
+	    -Wno-unused-value \
+	    -Wno-pointer-sign \
+	    -Wno-compare-distinct-pointer-types \
+	    -Werror \
+	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+
 run: all
-	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" V=$(V) $(TEST_RUNNER) $(TEST_FILE)
+	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" V=$(V) $(TEST_RUNNER) $(TEST_FILE) $(RUN_TESTS)

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt
+USER_TARGETS := test_xsk_refcnt check_kern_compat
 USER_LIBS := -lpthread
 
 EXTRA_DEPS +=

--- a/lib/libxdp/tests/check_kern_compat.c
+++ b/lib/libxdp/tests/check_kern_compat.c
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include "test_utils.h"
+#include "../libxdp_internal.h"
+
+int main(__unused int argc, __unused char** argv)
+{
+	silence_libbpf_logging();
+	return libxdp_check_kern_compat();
+}

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-ALL_TESTS="test_link_so test_link_a test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy"
+ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy"
 
 TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
@@ -71,6 +71,16 @@ test_xdp_frags()
         check_run $TESTS_DIR/test_xdp_frags xdp_veth_big0 xdp_veth_small0 2>&1
         ip link delete xdp_veth_big0
         ip link delete xdp_veth_small0
+}
+
+test_old_dispatcher()
+{
+        skip_if_missing_libxdp_compat
+
+        check_mount_bpffs || return 1
+        ip link add xdp_veth0 type veth peer name xdp_veth1
+        check_run $TESTS_DIR/test_dispatcher_versions xdp_veth0
+        ip link delete xdp_veth0
 }
 
 cleanup_tests()

--- a/lib/libxdp/tests/test_dispatcher_versions.c
+++ b/lib/libxdp/tests/test_dispatcher_versions.c
@@ -1,0 +1,300 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <linux/err.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+#include "../libxdp_internal.h"
+#include "xdp_dispatcher_v1.h"
+
+#include <xdp/libxdp.h>
+#include <bpf/libbpf.h>
+#include <bpf/btf.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define BPFFS_DIR "/sys/fs/bpf/xdp"
+
+#define PROG_RUN_PRIO 42
+#define PROG_CHAIN_CALL_ACTIONS (1 << XDP_DROP)
+
+int get_prog_id(int prog_fd)
+{
+	struct bpf_prog_info info = {};
+	__u32 len = sizeof(info);
+        int err;
+
+	err = bpf_obj_get_info_by_fd(prog_fd, &info, &len);
+	if (err)
+                return -errno;
+
+        return info.id;
+}
+
+int load_dispatcher_v1(int ifindex)
+{
+	struct xdp_dispatcher_config_v1 dispatcher_config = {};
+        struct bpf_object *obj_dispatcher, *obj_prog = NULL;
+	DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
+        struct bpf_program *dispatcher_prog, *xdp_prog;
+        int ret, btf_id, lfd = -1, dispatcher_id;
+	char pin_path[PATH_MAX], buf[PATH_MAX];
+        const char *attach_func = "prog0";
+        struct bpf_map *map;
+
+        if (!ifindex)
+                return -ENOENT;
+
+	obj_dispatcher = bpf_object__open("xdp_dispatcher_v1.o");
+        if (!obj_dispatcher)
+                return -errno;
+
+	btf_id = btf__find_by_name_kind(bpf_object__btf(obj_dispatcher),
+                                        attach_func, BTF_KIND_FUNC);
+	if (btf_id <= 0) {
+		ret = -ENOENT;
+		goto out;
+	}
+	opts.target_btf_id = btf_id;
+
+        map = bpf_object__next_map(obj_dispatcher, NULL);
+	if (!map) {
+		ret = -ENOENT;
+		goto out;
+	}
+
+        dispatcher_prog = bpf_object__find_program_by_name(obj_dispatcher,
+                                                          "xdp_dispatcher");
+	if (!dispatcher_prog) {
+		ret = -errno;
+		goto out;
+	}
+
+        dispatcher_config.num_progs_enabled = 1;
+        dispatcher_config.chain_call_actions[0] = PROG_CHAIN_CALL_ACTIONS;
+        dispatcher_config.run_prios[0] = PROG_RUN_PRIO;
+
+        ret = bpf_map__set_initial_value(map, &dispatcher_config,
+                                         sizeof(dispatcher_config));
+        if (ret)
+                goto out;
+
+
+        ret = bpf_object__load(obj_dispatcher);
+        if (ret)
+                goto out;
+
+        dispatcher_id = get_prog_id(bpf_program__fd(dispatcher_prog));
+	if (dispatcher_id < 0) {
+		ret = dispatcher_id;
+		goto out;
+	}
+
+	obj_prog = bpf_object__open("xdp_pass.o");
+	if (!obj_prog) {
+		ret = -errno;
+		goto out;
+	}
+
+        xdp_prog = bpf_object__find_program_by_name(obj_prog, "xdp_pass");
+	if (!xdp_prog) {
+		ret = -errno;
+		goto out;
+	}
+
+	ret = bpf_program__set_attach_target(xdp_prog,
+                                             bpf_program__fd(dispatcher_prog),
+                                             attach_func);
+        if (ret)
+                goto out;
+
+        bpf_program__set_type(xdp_prog, BPF_PROG_TYPE_EXT);
+        bpf_program__set_expected_attach_type(xdp_prog, 0);
+
+        ret = bpf_object__load(obj_prog);
+        if (ret)
+                goto out;
+
+        lfd = bpf_link_create(bpf_program__fd(xdp_prog),
+                              bpf_program__fd(dispatcher_prog), 0, &opts);
+	if (lfd < 0) {
+		ret = -errno;
+		goto out;
+	}
+
+	ret = try_snprintf(pin_path, sizeof(pin_path), "%s/dispatch-%d-%d",
+			   BPFFS_DIR, ifindex, dispatcher_id);
+	if (ret)
+		goto out;
+
+	ret = mkdir(BPFFS_DIR, S_IRWXU);
+	if (ret && errno != EEXIST) {
+		ret = -errno;
+                printf("mkdir err (%s): %s\n", BPFFS_DIR, strerror(-ret));
+		goto out;
+	}
+
+	ret = mkdir(pin_path, S_IRWXU);
+	if (ret) {
+		ret = -errno;
+                printf("mkdir err (%s): %s\n", pin_path, strerror(-ret));
+		goto out;
+	}
+
+        ret = try_snprintf(buf, sizeof(buf), "%s/prog0-link", pin_path);
+        if (ret)
+                goto err_unpin;
+
+        ret = bpf_obj_pin(lfd, buf);
+        if (ret)
+                goto err_unpin;
+
+        ret = try_snprintf(buf, sizeof(buf), "%s/prog0-prog", pin_path);
+        if (ret)
+                goto err_unpin;
+
+        ret = bpf_obj_pin(bpf_program__fd(xdp_prog), buf);
+        if (ret)
+                goto err_unpin;
+
+        ret = xdp_attach_fd(bpf_program__fd(dispatcher_prog), -1, ifindex,
+                            XDP_MODE_NATIVE);
+        if (ret)
+                goto err_unpin;
+
+out:
+        if (lfd >= 0)
+                close(lfd);
+        bpf_object__close(obj_dispatcher);
+        bpf_object__close(obj_prog);
+        return ret;
+
+err_unpin:
+        if (!try_snprintf(buf, sizeof(buf), "%s/prog0-link", pin_path))
+                unlink(buf);
+        if (!try_snprintf(buf, sizeof(buf), "%s/prog0-prog", pin_path))
+                unlink(buf);
+        rmdir(pin_path);
+        goto out;
+}
+
+int check_old_dispatcher(int ifindex)
+{
+        struct xdp_multiprog *mp = NULL;
+        struct xdp_program *xdp_prog;
+        char buf[100];
+        int ret;
+
+        ret = load_dispatcher_v1(ifindex);
+        if (ret)
+                goto out;
+
+        mp = xdp_multiprog__get_from_ifindex(ifindex);
+        ret = libxdp_get_error(mp);
+	if (ret)
+		goto out;
+
+	if (xdp_multiprog__is_legacy(mp)) {
+		printf("Got unexpected legacy multiprog\n");
+                ret = -EINVAL;
+                goto out;
+	}
+
+	if (xdp_multiprog__program_count(mp) != 1) {
+		printf("Expected 1 attached program, got %d\n",
+                       xdp_multiprog__program_count(mp));
+                ret = -EINVAL;
+                goto out;
+	}
+
+        xdp_prog = xdp_multiprog__next_prog(NULL, mp);
+	if (!xdp_prog) {
+		ret = -errno;
+		goto out;
+	}
+
+	if (strcmp(xdp_program__name(xdp_prog), "xdp_pass")) {
+		printf("Expected xdp_pass program, got %s\n",
+		       xdp_program__name(xdp_prog));
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (xdp_program__run_prio(xdp_prog) != PROG_RUN_PRIO) {
+		printf("Expected run prio %d got %d\n", PROG_RUN_PRIO,
+		       xdp_program__run_prio(xdp_prog));
+		ret = -EINVAL;
+		goto out;
+	}
+
+        ret = xdp_program__print_chain_call_actions(xdp_prog, buf, sizeof(buf));
+        if (ret)
+                goto out;
+
+	if (strcmp(buf, "XDP_DROP")) {
+		printf("Expected actions XDP_PASS, got %s\n", buf);
+		ret = -EINVAL;
+		goto out;
+	}
+
+        xdp_prog = xdp_program__open_file("xdp_pass.o", "xdp", NULL);
+        ret = libxdp_get_error(xdp_prog);
+        if (ret)
+                goto out;
+
+        ret = xdp_program__attach(xdp_prog, ifindex, XDP_MODE_NATIVE, 0);
+        xdp_program__close(xdp_prog);
+	if (!ret) {
+		printf("Shouldn't have been able to attach a new program to ifindex!\n");
+		ret = -EINVAL;
+		goto out;
+	}
+        ret = 0;
+
+out:
+        if (mp)
+                xdp_multiprog__detach(mp);
+        xdp_multiprog__close(mp);
+        return ret;
+}
+
+static void usage(char *progname)
+{
+	fprintf(stderr, "Usage: %s <ifname>\n", progname);
+	exit(EXIT_FAILURE);
+}
+
+int main(int argc, char **argv)
+{
+        int ifindex, ret;
+        char *envval;
+
+        envval = secure_getenv("VERBOSE_TESTS");
+
+	silence_libbpf_logging();
+        if (envval && envval[0] == '1')
+                verbose_libxdp_logging();
+        else
+                silence_libxdp_logging();
+
+	if (argc != 2)
+                usage(argv[0]);
+
+	ifindex = if_nametoindex(argv[1]);
+
+        ret = check_old_dispatcher(ifindex);
+
+        return ret;
+}

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -23,6 +23,13 @@ trap 'status=$?; rm -rf $TMPDIR; exit $status' EXIT HUP INT QUIT TERM
 # Odd return value for skipping, as only 0-255 is valid.
 SKIPPED_TEST=249
 
+skip_if_missing_libxdp_compat()
+{
+    if ! $TEST_PROG_DIR/check_kern_compat; then
+        exit "$SKIPPED_TEST"
+    fi
+}
+
 is_func()
 {
     type "$1" 2>/dev/null | grep -q 'is a function'

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -16,6 +16,8 @@ TEST_PROG_DIR="${TEST_PROG_DIR:-$(dirname "${BASH_SOURCE[0]}")}"
 ALL_TESTS=""
 VERBOSE_TESTS=${V:-0}
 
+export VERBOSE_TESTS
+
 TMPDIR=$(mktemp --tmpdir -d config.XXXXXX)
 trap 'status=$?; rm -rf $TMPDIR; exit $status' EXIT HUP INT QUIT TERM
 

--- a/lib/libxdp/tests/test_utils.h
+++ b/lib/libxdp/tests/test_utils.h
@@ -4,6 +4,7 @@
 #define __TEST_UTILS_H
 
 #include <bpf/libbpf.h>
+#include <xdp/libxdp.h>
 
 #define __unused __attribute__((unused))
 
@@ -14,9 +15,35 @@ static int libbpf_silent_func(__unused enum libbpf_print_level level,
 	return 0;
 }
 
-static void silence_libbpf_logging(void)
+static inline void silence_libbpf_logging(void)
 {
 	libbpf_set_print(libbpf_silent_func);
+}
+
+static int libxdp_silent_func(__unused enum libxdp_print_level level,
+			      __unused const char *format,
+			      __unused va_list args)
+{
+	return 0;
+}
+
+static int libxdp_verbose_func(__unused enum libxdp_print_level level,
+			       __unused const char *format,
+			       __unused va_list args)
+{
+	fprintf(stderr, "  ");
+	vfprintf(stderr, format, args);
+	return 0;
+}
+
+static inline void silence_libxdp_logging(void)
+{
+	libxdp_set_print(libxdp_silent_func);
+}
+
+static inline void verbose_libxdp_logging(void)
+{
+	libxdp_set_print(libxdp_verbose_func);
 }
 
 #endif

--- a/lib/libxdp/tests/test_xdp_frags.c
+++ b/lib/libxdp/tests/test_xdp_frags.c
@@ -1,0 +1,339 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <linux/err.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+
+#include <xdp/libxdp.h>
+#include <bpf/libbpf.h>
+
+# define ARRAY_SIZE(_x) (sizeof(_x) / sizeof((_x)[0]))
+
+static bool kern_compat;
+
+
+static struct xdp_program *load_prog(void)
+{
+        DECLARE_LIBXDP_OPTS(xdp_program_opts, opts,
+                            .prog_name = "xdp_pass",
+                            .find_filename = "xdp-dispatcher.o",
+                );
+        return xdp_program__create(&opts);
+}
+
+static int check_attached_progs(int ifindex, int count, bool frags)
+{
+        struct xdp_multiprog *mp;
+        int ret;
+
+        /* If the kernel does not support frags, we always expect
+         * frags support to be disabled on a returned dispatcher
+         */
+        if (!kern_compat)
+                frags = false;
+
+        mp = xdp_multiprog__get_from_ifindex(ifindex);
+        ret = libxdp_get_error(mp);
+	if (ret) {
+		fprintf(stderr, "Couldn't get multiprog on ifindex %d: %s\n",
+			ifindex, strerror(-ret));
+		return ret;
+	}
+
+        ret = -EINVAL;
+
+	if (xdp_multiprog__is_legacy(mp)) {
+		fprintf(stderr, "Found legacy prog on ifindex %d\n", ifindex);
+		goto out;
+	}
+
+	if (xdp_multiprog__program_count(mp) != count) {
+		fprintf(stderr, "Expected %d programs loaded on ifindex %d, found %d\n",
+                        count, ifindex, xdp_multiprog__program_count(mp));
+		goto out;
+	}
+
+	if (xdp_multiprog__xdp_frags_support(mp) != frags) {
+		fprintf(stderr,
+			"Multiprog on ifindex %d %s frags, expected %s\n",
+			ifindex,
+			xdp_multiprog__xdp_frags_support(mp) ?
+				"supports" :
+				"does not support",
+			frags ? "support" : "no support");
+                goto out;
+	}
+
+        ret = 0;
+
+out:
+        xdp_multiprog__close(mp);
+        return ret;
+}
+
+static void print_test_result(const char *func, int ret)
+{
+        fflush(stderr);
+	fprintf(stderr, "%s:\t%s\n", func, ret ? "FAILED" : "PASSED");
+        fflush(stdout);
+}
+
+static int load_attach_prog(struct xdp_program **prog, int ifindex, bool frags)
+{
+        int ret;
+
+        *prog = load_prog();
+	if (!*prog) {
+		ret = -errno;
+		fprintf(stderr, "Couldn't load program: %s\n", strerror(-ret));
+		return ret;
+	}
+
+        ret = xdp_program__set_xdp_frags_support(*prog, frags);
+        if (ret)
+                return ret;
+
+        return xdp_program__attach(*prog, ifindex, XDP_MODE_NATIVE, 0);
+}
+
+static int _check_load(int ifindex, bool frags, bool should_succeed)
+{
+        struct xdp_program *prog = NULL;
+        bool attached;
+        int ret;
+
+        ret = load_attach_prog(&prog, ifindex, frags);
+        attached = !ret;
+
+	if (attached != should_succeed) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+        if (should_succeed)
+                ret = check_attached_progs(ifindex, 1, frags);
+        else
+                ret = 0;
+
+out:
+        if (attached)
+                xdp_program__detach(prog, ifindex, XDP_MODE_NATIVE, 0);
+        xdp_program__close(prog);
+        return ret;
+}
+
+static int check_load_frags(int ifindex_bigmtu, int ifindex_smallmtu)
+{
+        int ret = _check_load(ifindex_smallmtu, true, true);
+        if (!ret && ifindex_bigmtu)
+                _check_load(ifindex_bigmtu, true, true);
+        print_test_result(__func__, ret);
+        return ret;
+}
+
+static int check_load_nofrags_success(int ifindex)
+{
+        int ret = _check_load(ifindex, false, true);
+        print_test_result(__func__, ret);
+        return ret;
+}
+
+static int check_load_nofrags_fail(int ifindex)
+{
+        int ret = _check_load(ifindex, false, false);
+        print_test_result(__func__, ret);
+        return ret;
+}
+static int check_load_frags_multi(int ifindex)
+{
+        struct xdp_program *prog1 = NULL, *prog2 = NULL;
+        int ret;
+
+        ret = load_attach_prog(&prog1, ifindex, true);
+        if (ret)
+                goto out;
+
+        ret = load_attach_prog(&prog2, ifindex, true);
+        if (ret)
+                goto out_prog1;
+
+        ret = check_attached_progs(ifindex, 2, true);
+
+        xdp_program__detach(prog2, ifindex, XDP_MODE_NATIVE, 0);
+out_prog1:
+        xdp_program__detach(prog1, ifindex, XDP_MODE_NATIVE, 0);
+out:
+        xdp_program__close(prog2);
+        xdp_program__close(prog1);
+        print_test_result(__func__, ret);
+        return ret;
+}
+
+static int check_load_mix_small(int ifindex)
+{
+        struct xdp_program *prog1 = NULL, *prog2 = NULL;
+        int ret;
+
+        ret = load_attach_prog(&prog1, ifindex, true);
+        if (ret)
+                goto out;
+
+        /* First program attached, dispatcher supports frags */
+	ret = check_attached_progs(ifindex, 1, true);
+        if (ret)
+                goto out;
+
+        ret = load_attach_prog(&prog2, ifindex, false);
+	if (ret)
+		goto out_prog1;
+
+        /* Mixed program attachment, dispatcher should not support frags */
+	ret = check_attached_progs(ifindex, 2, false);
+
+        ret = xdp_program__detach(prog2, ifindex, XDP_MODE_NATIVE, 0) || ret;
+        if (ret)
+                goto out_prog1;
+
+        /* Second program removed, back to frags-only */
+	ret = check_attached_progs(ifindex, 1, true) || ret;
+
+out_prog1:
+        xdp_program__detach(prog1, ifindex, XDP_MODE_NATIVE, 0);
+
+out:
+        xdp_program__close(prog2);
+        xdp_program__close(prog1);
+        print_test_result(__func__, ret);
+        return ret;
+}
+
+static int check_load_mix_big(int ifindex)
+{
+        struct xdp_program *prog1 = NULL, *prog2 = NULL;
+        int ret;
+
+        ret = load_attach_prog(&prog1, ifindex, true);
+        if (ret)
+                goto out;
+
+        /* First program attached, dispatcher supports frags */
+	ret = check_attached_progs(ifindex, 1, true);
+        if (ret)
+                goto out;
+
+        /* Second non-frags program should fail on big-MTU device */
+        ret = load_attach_prog(&prog2, ifindex, false);
+	if (!ret) {
+		xdp_program__detach(prog2, ifindex, XDP_MODE_NATIVE, 0);
+		ret = -EINVAL;
+		goto out_prog1;
+	}
+
+	/* Still only a single program loaded, with frags support */
+	ret = check_attached_progs(ifindex, 1, true);
+
+out_prog1:
+        xdp_program__detach(prog1, ifindex, XDP_MODE_NATIVE, 0);
+
+out:
+        xdp_program__close(prog2);
+        xdp_program__close(prog1);
+        print_test_result(__func__, ret);
+        return ret;
+}
+
+
+static bool check_frags_compat(void)
+{
+	struct xdp_program *test_prog;
+        struct bpf_program *prog;
+        struct bpf_object *obj;
+	bool ret = false;
+        int err;
+
+	test_prog = load_prog();
+	if (!test_prog)
+		return false;
+
+        obj = xdp_program__bpf_obj(test_prog);
+        if (!obj)
+                goto out;
+
+        prog = bpf_object__find_program_by_name(obj, "xdp_pass");
+        if (!prog)
+                goto out;
+
+	bpf_program__set_flags(prog, BPF_F_XDP_HAS_FRAGS);
+        err = bpf_object__load(obj);
+	if (!err) {
+		printf("Kernel supports XDP programs with frags\n");
+                ret = true;
+	} else {
+		printf("Kernel DOES NOT support XDP programs with frags\n");
+	}
+        fflush(stdout);
+
+out:
+	xdp_program__close(test_prog);
+	return ret;
+}
+
+static void usage(char *progname)
+{
+	fprintf(stderr, "Usage: %s <ifname_bigmtu> <ifname_smallmtu>\n", progname);
+	exit(EXIT_FAILURE);
+}
+
+int main(int argc, char **argv)
+{
+	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	int ifindex_bigmtu, ifindex_smallmtu, ret;
+        char *envval;
+
+        envval = secure_getenv("VERBOSE_TESTS");
+
+	silence_libbpf_logging();
+        if (envval && envval[0] == '1')
+                verbose_libxdp_logging();
+        else
+                silence_libxdp_logging();
+
+        kern_compat = check_frags_compat();
+
+	if (argc != 3)
+                usage(argv[0]);
+
+	ifindex_bigmtu = if_nametoindex(argv[1]);
+	ifindex_smallmtu = if_nametoindex(argv[2]);
+	if (!ifindex_bigmtu || !ifindex_smallmtu) {
+		fprintf(stderr, "Interface '%s' or '%s' not found.\n", argv[1], argv[2]);
+                usage(argv[0]);
+	}
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+        ret = check_load_frags(kern_compat ? ifindex_bigmtu : 0, ifindex_smallmtu);
+        ret = check_load_nofrags_success(ifindex_smallmtu) || ret;
+	if (kern_compat) {
+		ret = check_load_nofrags_fail(ifindex_bigmtu) || ret;
+		ret = check_load_frags_multi(ifindex_bigmtu) || ret;
+                ret = check_load_mix_big(ifindex_bigmtu) || ret;
+	}
+	ret = check_load_mix_small(ifindex_smallmtu) || ret;
+
+	return ret;
+}

--- a/lib/libxdp/tests/xdp_dispatcher_v1.c
+++ b/lib/libxdp/tests/xdp_dispatcher_v1.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include "xdp_dispatcher_v1.h"
+
+#define XDP_METADATA_SECTION "xdp_metadata"
+#define XDP_DISPATCHER_VERSION_V1 1
+#define XDP_DISPATCHER_RETVAL 31
+
+
+static volatile const struct xdp_dispatcher_config_v1 conf = {};
+
+__attribute__ ((noinline))
+int prog0(struct xdp_md *ctx) {
+        volatile int ret = XDP_DISPATCHER_RETVAL;
+
+        if (!ctx)
+          return XDP_ABORTED;
+        return ret;
+}
+__attribute__ ((noinline))
+
+SEC("xdp")
+int xdp_dispatcher(struct xdp_md *ctx)
+{
+        __u8 num_progs_enabled = conf.num_progs_enabled;
+        int ret;
+
+        if (num_progs_enabled < 1)
+                goto out;
+        ret = prog0(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[0]))
+                return ret;
+
+out:
+        return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";
+__uint(dispatcher_version, XDP_DISPATCHER_VERSION_V1) SEC(XDP_METADATA_SECTION);

--- a/lib/libxdp/tests/xdp_dispatcher_v1.h
+++ b/lib/libxdp/tests/xdp_dispatcher_v1.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __XDP_DISPATCHER_V1_H
+#define __XDP_DISPATCHER_V1_H
+
+#ifndef MAX_DISPATCHER_ACTIONS
+#define MAX_DISPATCHER_ACTIONS 10
+#endif
+
+struct xdp_dispatcher_config_v1 {
+	__u8 num_progs_enabled;
+	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
+	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
+};
+
+#endif

--- a/lib/libxdp/tests/xdp_pass.c
+++ b/lib/libxdp/tests/xdp_pass.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("xdp")
+int xdp_pass(struct xdp_md *ctx)
+{
+        return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
To enable the use of XDP with large MTUs, the kernel added support for
addressing multiple packet fragments from XDP, AKA "XDP frags" in kernel
version 5.18. This support is opt-in from the program side since it changes
the semantics of the XDP program: The full packet data is no longer
guaranteed to be addressable through the data and data_end pointers of the
XDP context object, and the XDP program has to use a new API to access
packet data after the first fragment.

An XDP program opts in to using this support by setting the
BPF_F_XDP_HAS_FRAGS flag when loading a program, and the kernel only allows
attaching an XDP program to a large-MTU device if this flag is set.
However, because libxdp did not understand the flag, frags support could
not be used at all with libxdp (even if a program set the flag, this would
not be propagated to the dispatcher, so from the kernel PoV it was never
set).

To fix this, we need to make libxdp aware of the frags support, and
properly propagate the flag. Since libxdp, by its nature, allows attaching
multiple programs, some care has to be taken when mixing them: the frags
flag should only be propagated to the dispatcher if all programs attached
to it set the flag. Otherwise, a non-frags aware program may be exposed to
a multi-frag packet and malfunction in a subtle way. The converse, however,
is OK: A frags-aware program can be loaded without the frags flag set, the
resulting dispatcher just won't be attachable to a device with a big MTU.

Because it is not possible to query the kernel and learn whether an
already-loaded program has the frags flag set, we need to store this
information ourselves. This means we have to change the format of the
dispatcher data structure, so this patch also bumps dispatcher version
field. Unfortunately, this means that this patch breaks
backwards-compatibility with older versions of libxdp: if a program is
loaded with libxdp after this patch, older versions of libxdp will refuse
to touch that dispatcher. Conversely, if this version of libxdp encounters
an older dispatcher, it will upgrade it to the newer version, so
compatibility with that older version is also lost.


Fixes #235.