### PR TITLE
xdp/xsk.h: Fix undefined XDP_ALWAYS_INLINE with sparse

### DIFF
--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -25,6 +25,8 @@ extern "C" {
 #define XDP_ALWAYS_INLINE inline __attribute__((__always_inline__))
 #elif __GNUC_GNU_INLINE__
 #define XDP_ALWAYS_INLINE static inline __attribute__((__always_inline__))
+#else
+#define XDP_ALWAYS_INLINE static inline
 #endif
 
 /* Do not access these members directly. Use the functions below. */


### PR DESCRIPTION
Sparse checker doesn't have __GNUC_GNU_INLINE__ or __GNUC_STDC_INLINE__ defined, the same will be true for any non-GNU compiler.

This is causing build failures due to XDP_ALWAYS_INLINE being undefined.

This is potentially not the best way of fixing the problem, but it solves the current issue.

Closes: #279
Fixes: 83549d3a2e66 ("xdp/xsk.h: Fix compilation with -std=gnu89")
Reported-by: David Marchand \<dmarchan@redhat.com\>
Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>