### PR TITLE
Update CI to a newer kernel

### DIFF
--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       matrix:
         include:
+         - KERNEL_VERSION: 6.1.9
+           KERNEL_PATCH_VERSION: 200.fc37
+           DID_UNSHARE: 0
          - KERNEL_VERSION: 5.16.8
            KERNEL_PATCH_VERSION: 200.fc35
            DID_UNSHARE: 0

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -145,8 +145,6 @@ skip_if_missing_cpumap_attach()
     if ! $TEST_PROG_DIR/test-tool probe cpumap-prog; then
         exit "$SKIPPED_TEST"
     fi
-
-    bpftool feature list_builtins attach_types
 }
 
 skip_if_missing_kernel_symbol()


### PR DESCRIPTION
Add a 6.1 kernel to the test matrix. Also remove a leftover command from the
test runners.