### PR TITLE
libxdp: Make sure we cleanup the temporary directory in selftests

### DIFF
--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -6,6 +6,7 @@ TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 test_link_so()
 {
+        TMPDIR=$(mktemp --tmpdir -d libxdp-test.XXXXXX)
         cat >$TMPDIR/libxdptest.c <<EOF
 #include <xdp/libxdp.h>
 int main(int argc, char **argv) {
@@ -14,11 +15,15 @@ int main(int argc, char **argv) {
     return 0;
 }
 EOF
-        check_run $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -lxdp $LDLIBS 2>&1
+        $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -lxdp $LDLIBS 2>&1
+        retval=$?
+        rm -rf "$TMPDIR"
+        return $retval
 }
 
 test_link_a()
 {
+        TMPDIR=$(mktemp --tmpdir -d libxdp-test.XXXXXX)
         cat >$TMPDIR/libxdptest.c <<EOF
 #include <xdp/libxdp.h>
 int main(int argc, char **argv) {
@@ -27,7 +32,10 @@ int main(int argc, char **argv) {
     return 0;
 }
 EOF
-        check_run $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -l:libxdp.a $LDLIBS 2>&1
+        $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -l:libxdp.a $LDLIBS 2>&1
+        retval=$?
+        rm -rf "$TMPDIR"
+        return $retval
 }
 
 test_refcnt_once()

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -18,10 +18,6 @@ VERBOSE_TESTS=${V:-0}
 
 export VERBOSE_TESTS
 
-TMPDIR=$(mktemp --tmpdir -d config.XXXXXX)
-trap 'status=$?; rm -rf $TMPDIR; exit $status' EXIT HUP INT QUIT TERM
-
-
 # Odd return value for skipping, as only 0-255 is valid.
 SKIPPED_TEST=249
 


### PR DESCRIPTION
The libxdp selftests were leaking the temporary directory it was creating.
Move the creation and deletion into the tests that actually use it instead
of having a global one created in test-runner.sh.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>