### PR TITLE
Fix compile error due to variable declaration inside a 'switch' case

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -2186,6 +2186,7 @@ static int check_dispatcher_version(struct xdp_multiprog *mp,
 
 	switch (version) {
 	case XDP_DISPATCHER_VERSION_V1:
+	{
 		struct xdp_dispatcher_config_v1 *config = (void *)buf;
 
 		for (i = 0; i < MAX_DISPATCHER_ACTIONS; i++) {
@@ -2194,7 +2195,7 @@ static int check_dispatcher_version(struct xdp_multiprog *mp,
 		}
 		mp->config.num_progs_enabled = config->num_progs_enabled;
 		break;
-
+	}
 	case XDP_DISPATCHER_VERSION:
 		if (map_info.value_size != sizeof(mp->config)) {
 			pr_warn("Dispatcher version matches, but map size %u != expected %zu\n",


### PR DESCRIPTION
A recently added 'switch' statement for handling different dispatcher types includes a line of code where a variable is declared immediately after a case label without being enclosed in braces.

This causes compilation failures with certain compilers, which appear as:

    libxdp.c: In function 'check_dispatcher_version':
    libxdp.c:2189:3: error: a label can only be part of a statement and a declaration is not a statement
     2189 |   struct xdp_dispatcher_config_v1 *config = (void *)buf;
          |   ^~~~~~

Adding braces around the code for the case will avoid this problem.

Observed when following the standard build instructions on Ubuntu 20.04 (gcc 9.4.0, clang 15.0.7).