### PR TITLE
Link with -lm to fix build on arm/mips/risc/ppc

### DIFF
--- a/lib/common.mk
+++ b/lib/common.mk
@@ -24,6 +24,7 @@ MAN_FILES := $(MAN_PAGE)
 # Expect this is defined by including Makefile, but define if not
 LIB_DIR ?= ../lib
 LDLIBS ?= $(USER_LIBS)
+LDLIBS += -lm
 
 include $(LIB_DIR)/defines.mk
 include $(LIB_DIR)/libxdp/libxdp.mk

--- a/xdp-bench/Makefile
+++ b/xdp-bench/Makefile
@@ -11,7 +11,6 @@ TOOL_NAME := xdp-bench
 MAN_PAGE := xdp-bench.8
 TEST_FILE := tests/test-xdp-bench.sh
 USER_TARGETS := xdp-bench
-USER_LIBS     = -lm
 USER_EXTRA_C := xdp_redirect_basic.c xdp_redirect_cpumap.c xdp_redirect_devmap.c \
 		xdp_redirect_devmap_multi.c xdp_basic.c
 EXTRA_USER_DEPS := xdp-bench.h

--- a/xdp-monitor/Makefile
+++ b/xdp-monitor/Makefile
@@ -11,7 +11,6 @@ MAN_PAGE := xdp-monitor.8
 TEST_FILE := tests/test-xdp-monitor.sh
 USER_TARGETS := xdp-monitor
 LIB_DIR       = ../lib
-USER_LIBS     = -lm
 
 include $(LIB_DIR)/common.mk
 


### PR DESCRIPTION
xdp_sample uses floor()/ceil() so every executable that imports that module needs to link with -lm. E.g. on armhf:

```
gcc -Wall -O2 -g -std=gnu11 -Wextra -Werror -DBPF_DIR_MNT=\"/sys/fs/bpf\" -DBPF_OBJECT_PATH=\"/usr/local/lib/bpf\" -DMAX_DISPATCHER_ACTIONS=10 -DTOOLS_VERSION=\""1.3.0"\" -DLIBBPF_VERSION=\"1.1.0\" -DRUNDIR=\"/run\" -DHAVE_LIBBPF_PERF_BUFFER__CONSUME -DHAVE_LIBBPF_BTF__LOAD_FROM_KERNEL_BY_ID -DHAVE_LIBBPF_BTF__TYPE_CNT -DHAVE_LIBBPF_BPF_OBJECT__NEXT_MAP -DHAVE_LIBBPF_BPF_OBJECT__NEXT_PROGRAM -DHAVE_LIBBPF_BPF_PROGRAM__INSN_CNT -DHAVE_LIBBPF_BPF_MAP_CREATE -DHAVE_LIBBPF_PERF_BUFFER__NEW_RAW -DHAVE_LIBBPF_BPF_XDP_ATTACH -DHAVE_LIBBPF_BPF_MAP__SET_AUTOCREATE -DHAVE_LIBBPF_BPF_PROG_TEST_RUN_OPTS -DHAVE_SECURE_GETENV -DLIBBPF_DYNAMIC -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I../../headers -I../util   -L../libxdp -o test-tool ../util/params.o ../util/logging.o ../util/util.o ../util/stats.o ../util/xpcapng.o ../util/xdp_sample.o \
 test-tool.c  -l:libxdp.a  -lbpf
/usr/bin/ld: ../util/xdp_sample.o: in function `sample_round':
/home/bluca/xdp-tools-1.3.0/lib/util/xdp_sample.c:542: undefined reference to `trunc'
/usr/bin/ld: /home/bluca/xdp-tools-1.3.0/lib/util/xdp_sample.c:544: undefined reference to `ceil'
/usr/bin/ld: /home/bluca/xdp-tools-1.3.0/lib/util/xdp_sample.c:542: undefined reference to `floor'
```

Signed-off-by: Luca Boccassi <bluca@debian.org>