### PR TITLE
libxdp: Use prog->prog_name directly in debug output

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -3064,7 +3064,7 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 	for (prog = mp->first_prog; prog; prog = prog->next) {
 		if (prog->link_fd < 0) {
 			err = -EINVAL;
-			pr_warn("Prog %s not linked\n", xdp_program__name(prog));
+			pr_warn("Prog %s not linked\n", prog->prog_name);
 			goto err_unpin;
 		}
 
@@ -3079,8 +3079,7 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 			pr_warn("Couldn't pin link FD at %s: %s\n", buf, strerror(-err));
 			goto err_unpin;
 		}
-		pr_debug("Pinned link for prog %s at %s\n",
-			 xdp_program__name(prog), buf);
+		pr_debug("Pinned link for prog %s at %s\n", prog->prog_name, buf);
 
 		err = try_snprintf(buf, sizeof(buf), "%s/%s-prog",
 				   pin_path, prog->attach_name);
@@ -3094,7 +3093,7 @@ static int xdp_multiprog__pin(struct xdp_multiprog *mp)
 			goto err_unpin;
 		}
 
-		pr_debug("Pinned prog %s at %s\n", xdp_program__name(prog), buf);
+		pr_debug("Pinned prog %s at %s\n", prog->prog_name, buf);
 	}
 out:
 	xdp_lock_release(lock_fd);
@@ -3153,7 +3152,7 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 			goto out;
 		}
 		pr_debug("Unpinned link for prog %s from %s\n",
-			 xdp_program__name(prog), buf);
+			 prog->prog_name, buf);
 
 		err = try_snprintf(buf, sizeof(buf), "%s/%s-prog",
 				   pin_path, prog->attach_name);
@@ -3168,8 +3167,7 @@ static int xdp_multiprog__unpin(struct xdp_multiprog *mp)
 			goto out;
 		}
 
-		pr_debug("Unpinned prog %s from %s\n",
-			 xdp_program__name(prog), buf);
+		pr_debug("Unpinned prog %s from %s\n", prog->prog_name, buf);
 	}
 
 	err = rmdir(pin_path);


### PR DESCRIPTION
At higher optimisation levels, the compiler seems to think that the NULL
check in xdp_program__name() implies that the prog pointer can be NULL.
Which makes it complain about the unconditional use in debug output with
somewhat cryptic errors like:

In file included from libxdp.c:37:
libxdp.c: In function ‘xdp_multiprog__pin’:
libxdp_internal.h:38:37: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
   38 |                 libxdp_print(level, "libxdp: " fmt, ##__VA_ARGS__); \
      |                                     ^~~~~~~~~~
libxdp_internal.h:43:28: note: in expansion of macro ‘__pr’
   43 | #define pr_debug(fmt, ...) __pr(LIBXDP_DEBUG, fmt, ##__VA_ARGS__)
      |                            ^~~~
libxdp.c:3097:17: note: in expansion of macro ‘pr_debug’
 3097 |                 pr_debug("Pinned prog %s at %s\n", xdp_program__name(prog), buf);
      |                 ^~~~~~~~

This is, in fact, a false positive, but in the absence of a way to tell the
compiler that, let's just change the code in question to use the
prog->prog_name field directly.

Fixes #294.