### PR TITLE
xdp-loader: Only load the BPF program we need from object files

### DIFF
--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -130,6 +130,7 @@ int do_load(const void *cfg, __unused const char *pin_root_path)
 retry:
 	for (i = 0; i < num_progs; i++) {
 		DECLARE_LIBXDP_OPTS(xdp_program_opts, xdp_opts, 0);
+		struct bpf_program *bpf_prog = NULL;
 
 		p = progs[i];
 		if (p)
@@ -156,6 +157,13 @@ retry:
 				opt->filenames.strings[i], errmsg);
 			goto out;
 		}
+
+		/* Disable autoload for all programs in the bpf object; libxdp
+		 * will make sure to turn it back on for the program that we're
+		 * actually loading
+		 */
+		bpf_object__for_each_program(bpf_prog, xdp_program__bpf_obj(p))
+			bpf_program__set_autoload(bpf_prog, false);
 
 		if (opt->prio) {
 			err = xdp_program__set_run_prio(p, opt->prio);


### PR DESCRIPTION
When xdp-loader is loading a BPF object file it'll do so through the libbpf
bpf_object__load() API. This loads the whole BPF object, including all BPF
programs defined in the object file. Apart from being wasteful (those
programs will just get unloaded from the kernel when xdp-loader exits),
this can also make loading fail if one of those programs are unable to be
loaded for whatever reason.

The concrete failure that was observed for this is older object files that
don't use the new-style SEC("xdp"), in which case libbpf will fail to set a
program type. For the program we're targeting as loading, libxdp will reset
the program type (to attach to a dispatcher), so we can load such programs,
but extra programs in the same object file that are compiled like this will
fail for no good reason.

As a solution, just disable autoloading of all programs in the object file
after loading it; libxdp will re-enable autoloading of the program we are
targeting to attach to the interface before loading it into the kernel.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>