### PR TITLE
configure: Fix function detection for btf__type_cnt()

### DIFF
--- a/configure
+++ b/configure
@@ -272,7 +272,7 @@ check_libbpf_functions()
 
     check_libbpf_function "perf_buffer__consume" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "btf__load_from_kernel_by_id" "(0)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
-    check_libbpf_function "btf__type_cnt" "(0)" "$LIBBPF_CFLAGS" "" "$LIBBPF_LDLIBS"
+    check_libbpf_function "btf__type_cnt" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_object__next_map" "(NULL, NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_object__next_program" "(NULL, NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_program__insn_cnt" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"


### PR DESCRIPTION
The configure check for btf__type_cnt() swapped two arguments in the
check_libbpf_function() call in the configure script, leading to the check
failing if LIBBPF_CFLAGS is non-empty. Make sure the arguments are in the
right order, and also pass a proper NULL parameter in the check instead of
a 0.

Fixes #298.