### PR TITLE
make: disable stack protector for BPF bits built by clang

### DIFF
--- a/lib/defines.mk
+++ b/lib/defines.mk
@@ -1,5 +1,5 @@
 CFLAGS ?= -O2 -g
-BPF_CFLAGS ?= -Wno-visibility
+BPF_CFLAGS ?= -Wno-visibility -fno-stack-protector
 BPF_TARGET ?= bpf
 
 HAVE_FEATURES :=


### PR DESCRIPTION
The clang toolchain might have stack-protection enabled by default (e.g. via platform configuration) and that won't work for BPF, so unconditionally disable it via -fno-stack-protector.
Fixes #299 