### PR TITLE
xdpdump: fix build with clang

### DIFF
--- a/xdp-dump/Makefile
+++ b/xdp-dump/Makefile
@@ -4,6 +4,10 @@ XDP_TARGETS  := xdpdump_bpf xdpdump_xdp
 USER_TARGETS := xdpdump
 TEST_FILE    := tests/test-xdpdump.sh
 
+# Disable warnings about VLAs not being at the end of a structure when building
+# with clang. The code is fine, but clang's complaint coupled with -Werror would
+# break the build. See https://github.com/xdp-project/xdp-tools/issues/304
+CFLAGS       += "-Wno-gnu-variable-sized-type-not-at-end"
 LIB_DIR       = ../lib
 USER_LIBS     = -lpcap
 MAN_PAGE     := xdpdump.8


### PR DESCRIPTION
When building all of xdp-tools with clang, the xdp-dump build fails due to 'classic' use of variable-length arrays and -Werror. Disable the warning and leave a breadcrumb to the discussion.

Fixes: #304
