### PR TITLE
libxdp: fix build on musl

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include <linux/err.h> /* ERR_PTR */
 #include <linux/if_link.h>


### PR DESCRIPTION
In musl, PATH_MAX is defined in limits.h. Include it in libxdp.c to fix building systems using musl libc.

libxdp.c: In function 'find_bpffs':
libxdp.c:406:33: error: 'PATH_MAX' undeclared (first use in this function)
  406 |         static char bpf_wrk_dir[PATH_MAX];
      |                                 ^~~~~~~~