### PR TITLE
test_xdp_frags: check for privs early

### DIFF
--- a/lib/libxdp/tests/test_xdp_frags.c
+++ b/lib/libxdp/tests/test_xdp_frags.c
@@ -298,6 +298,13 @@ int main(int argc, char **argv)
 {
 	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
 	int ifindex_bigmtu, ifindex_smallmtu, ret;
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
         char *envval;
 
         envval = secure_getenv("VERBOSE_TESTS");
@@ -307,8 +314,6 @@ int main(int argc, char **argv)
                 verbose_libxdp_logging();
         else
                 silence_libxdp_logging();
-
-        kern_compat = check_frags_compat();
 
 	if (argc != 3)
                 usage(argv[0]);
@@ -320,11 +325,7 @@ int main(int argc, char **argv)
                 usage(argv[0]);
 	}
 
-	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
-		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
-			strerror(errno));
-		exit(EXIT_FAILURE);
-	}
+        kern_compat = check_frags_compat();
 
         ret = check_load_frags(kern_compat ? ifindex_bigmtu : 0, ifindex_smallmtu);
         ret = check_load_nofrags_success(ifindex_smallmtu) || ret;


### PR DESCRIPTION
As currently written, `test_xdp_frags` if run without necessary permissions will loudly print "this kernel does NOT support xdp frags", and then exit on the `setrlimit()`. The same thing happens if the argument list is invalid. Instead, verify all this before performing the frag support check, so as not to dismay users (like me) who try using this program to check for frag support.

I didn't touch the formatting in this file so as to produce a minimal diff for review, but it's kinda all over the place.