### PR TITLE
util: Use bpf_trace_vprintk() directly in sample detection program

### DIFF
--- a/lib/util/xdp_sample.bpf.c
+++ b/lib/util/xdp_sample.bpf.c
@@ -10,8 +10,12 @@ SEC("tp_btf/xdp_cpumap_kthread")
 int BPF_PROG(tp_xdp_cpumap_kthread, int map_id, unsigned int processed,
 	     unsigned int drops, int sched, struct xdp_cpumap_stats *xdp_stats)
 {
-	bpf_printk("Stats: %d %u %u %d %d\n",
-		   map_id, processed, drops, sched, xdp_stats->pass);
+	static const char fmt[] = "Stats: %d %u %u %d %d\n";
+	unsigned long long args[] = {
+		map_id, processed, drops, sched, xdp_stats->pass
+	};
+
+	bpf_trace_vprintk(fmt, sizeof(fmt), args, sizeof(args));
 	return 0;
 }
 


### PR DESCRIPTION
The dummy program we use to feature detect for xdp-sample doesn't compile
on old versions of libbpf that don't have the macro feature that selects
bpf_trace_vprintk() if the number of args exceeds what bpf_trace_printk()
supports. To get around this, just use the bpf_trace_vprintk() helper
directly, which should hopefully work on old libbpf versions as well.

Fixes #315