### PR TITLE
util/xdp_sample: define bpf_trace_vprintk() if it doesn't exist

### DIFF
--- a/lib/util/xdp_sample.bpf.c
+++ b/lib/util/xdp_sample.bpf.c
@@ -6,6 +6,11 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 
+#ifndef HAVE_LIBBPF_BPF_PROGRAM__FLAGS
+/* bpf_trace_vprintk() appeared in the same libbpf version as bpf_program__flags() */
+static long (*bpf_trace_vprintk)(const char *fmt, __u32 fmt_size, const void *data, __u32 data_len) = (void *) 177;
+#endif
+
 SEC("tp_btf/xdp_cpumap_kthread")
 int BPF_PROG(tp_xdp_cpumap_kthread, int map_id, unsigned int processed,
 	     unsigned int drops, int sched, struct xdp_cpumap_stats *xdp_stats)


### PR DESCRIPTION
The bpf_trace_vprintk() helper was added to the libbpf headers in 0.6.0, so define it if it doesn't exist. We already detect the bpf_program__flags() helper which was added in the same version, so just use that define to guard the definition.