### PR TITLE
xdp-loader: also silence libbpf logging on unload

### DIFF
--- a/xdp-loader/xdp-loader.c
+++ b/xdp-loader/xdp-loader.c
@@ -272,6 +272,13 @@ int do_unload(const void *cfg, __unused const char *pin_root_path)
 		goto out;
 	}
 
+	/* The feature probing done by libxdp makes libbpf output confusing
+	 * error messages even on unload. Silence the logging so we can provide
+	 * our own messages instead; this is a noop if verbose logging is
+	 * enabled.
+	 */
+	silence_libbpf_logging();
+
 	mp = xdp_multiprog__get_from_ifindex(opt->iface.ifindex);
 	if (IS_ERR_OR_NULL(mp)) {
 		pr_warn("No XDP program loaded on %s\n", opt->iface.ifname);


### PR DESCRIPTION
In xdp-loader we explicitly silence libbpf logging before loading a program
because the output is unhelpful in most cases. With the addition of
multiprog probing we also get unhelpful output on unload, so also silence
the output there.

Reported-by: Simon Sundberg <Simon.Sundberg@kau.se>
Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>