### PR TITLE
util: Move program locking out of dispatch_commands()

### DIFF
--- a/lib/util/params.c
+++ b/lib/util/params.c
@@ -797,11 +797,7 @@ int dispatch_commands(const char *argv0, int argc, char **argv,
 	if (err)
 		goto out;
 
-	if (prog_lock_get(prog_name))
-		goto out;
-
 	ret = cmd->func(cfg, pin_root_path);
-	prog_lock_release(0);
 out:
 	free(cfg);
 	return ret;

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -88,8 +88,8 @@ int unlink_pinned_map(int dir_fd, const char *map_name);
 
 const char *action2str(__u32 action);
 
-int prog_lock_get(const char *progname);
-void prog_lock_release(int signal);
+int prog_lock_acquire(const char *directory);
+int prog_lock_release(int lock_fd);
 
 const char *get_libbpf_version(void);
 int iface_print_status(const struct iface *iface);


### PR DESCRIPTION
The dispatch_commands() helper takes a program lock and holds it while the
command is being executed. This was added for the use of xdp_filter, and is
really only needed for that; none of the other utilities really need
locking to synchronise with itself (and libxdp has its own locking for the
dispatcher).

Move the locking out of dispatch_commands() and instead add explicit lock
and unlock calls to each of the xdp-filter commands. While doing so, also
move the locking to use the same directory-fd based approach as the libxdp
locking uses. This has the benefit of not writing any lock files, so the
lock is automatically cleared when the application exits, even if it
crashes. This should fix any issues with stale lock files sticking around,
which we did not have any good way to clean up.

Fixes #317
Fixes #325