### PR TITLE
util/xdp_samples: Add compatibility defines for libbpf

### DIFF
--- a/configure
+++ b/configure
@@ -278,6 +278,7 @@ check_libbpf_functions()
     check_libbpf_function "bpf_program__insn_cnt" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_program__type" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_program__flags" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
+    check_libbpf_function "bpf_program__expected_attach_type" "(NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_map_create" "(0, NULL, 0, 0, 0, NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "perf_buffer__new_raw" "(0, 0, NULL, NULL, NULL, NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"
     check_libbpf_function "bpf_xdp_attach" "(0, 0, 0, NULL)" "" "$LIBBPF_CFLAGS" "$LIBBPF_LDLIBS"

--- a/lib/testing/test-tool.c
+++ b/lib/testing/test-tool.c
@@ -15,19 +15,10 @@
 #include "logging.h"
 #include "util.h"
 #include "xdp_sample.h"
+#include "compat.h"
 
 
 #define PROG_NAME "test-tool"
-
-
-#ifndef HAVE_LIBBPF_BPF_OBJECT__NEXT_PROGRAM
-static struct bpf_program *bpf_object__next_program(const struct bpf_object *obj,
-  						    struct bpf_program *prog)
-{
-  	return bpf_program__next(prog, obj);
-}
-#endif
-
 
 struct enum_val xdp_modes[] = {
        {"native", XDP_MODE_NATIVE},

--- a/lib/util/compat.h
+++ b/lib/util/compat.h
@@ -1,8 +1,11 @@
 #ifndef __COMPAT_H
 #define __COMPAT_H
 
+#include <bpf/btf.h>
+#include <bpf/libbpf.h>
+
 #ifndef HAVE_LIBBPF_BTF__TYPE_CNT
-static __u32 btf__type_cnt(const struct btf *btf)
+static inline __u32 btf__type_cnt(const struct btf *btf)
 {
 	/* old function didn't include 'void' type in count */
 	return btf__get_nr_types(btf) + 1;

--- a/lib/util/compat.h
+++ b/lib/util/compat.h
@@ -9,4 +9,26 @@ static __u32 btf__type_cnt(const struct btf *btf)
 }
 #endif
 
+#ifndef HAVE_LIBBPF_BPF_PROGRAM__TYPE
+static inline enum bpf_prog_type bpf_program__type(const struct bpf_program *prog)
+{
+	return bpf_program__get_type((struct bpf_program *)prog);
+}
+#endif
+
+#ifndef HAVE_LIBBPF_BPF_OBJECT__NEXT_PROGRAM
+static inline struct bpf_program *bpf_object__next_program(const struct bpf_object *obj,
+							   struct bpf_program *prog)
+{
+	return bpf_program__next(prog, obj);
+}
+#endif
+
+#ifndef HAVE_LIBBPF_BPF_PROGRAM__EXPECTED_ATTACH_TYPE
+static inline enum bpf_attach_type bpf_program__expected_attach_type(const struct bpf_program *prog)
+{
+	return bpf_program__get_expected_attach_type(prog);
+}
+#endif
+
 #endif

--- a/lib/util/xdp_sample.h
+++ b/lib/util/xdp_sample.h
@@ -6,6 +6,7 @@
 #include <getopt.h>
 
 #include <xdp/xdp_sample_shared.h>
+#include "compat.h"
 
 enum stats_mask {
 	_SAMPLE_REDIRECT_MAP         = 1U << 0,


### PR DESCRIPTION
The xdp_samples.h file was using some newer libbpf functions without the
required compatibility defines, leading to compilation errors on older
libbpf versions. Add the required defines to util/compat.h and include that
from xdp_sample.h. This includes a new configure check for
bpf_program__expected_attach_type(), which was renamed in libbpf 1.0.

Fixes #326