### PR TITLE
Minor packaging improvements

### DIFF
--- a/lib/common.mk
+++ b/lib/common.mk
@@ -73,7 +73,7 @@ install: all install_local
 	install -m 0755 -d $(DESTDIR)$(SBINDIR)
 	install -m 0755 -d $(DESTDIR)$(BPF_OBJECT_DIR)
 	$(if $(USER_TARGETS),install -m 0755 $(USER_TARGETS) $(DESTDIR)$(SBINDIR))
-	$(if $(XDP_OBJ_INSTALL),install -m 0755 $(XDP_OBJ_INSTALL) $(DESTDIR)$(BPF_OBJECT_DIR))
+	$(if $(XDP_OBJ_INSTALL),install -m 0644 $(XDP_OBJ_INSTALL) $(DESTDIR)$(BPF_OBJECT_DIR))
 	$(if $(MAN_FILES),install -m 0755 -d $(DESTDIR)$(MANDIR)/man8)
 	$(if $(MAN_FILES),install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man8)
 	$(if $(SCRIPTS_FILES),install -m 0755 -d $(DESTDIR)$(SCRIPTSDIR))

--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -54,7 +54,7 @@ install: all
 	$(Q)install -m 0644 $(LIB_HEADERS) $(DESTDIR)$(HDRDIR)/
 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
 	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
-	$(Q)install -m 0755 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
+	$(Q)install -m 0644 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
 	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
 	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
 

--- a/lib/util/xdp_sample.h
+++ b/lib/util/xdp_sample.h
@@ -54,7 +54,7 @@ const char *get_driver_name(int ifindex);
 int get_mac_addr(int ifindex, void *mac_addr);
 
 #pragma GCC diagnostic push
-#ifndef __clang__
+#if !defined(__clang__) && (__GNUC__ > 7)
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
 __attribute__((unused))


### PR DESCRIPTION
Some minor packaging-related changes while trying to package v1.3.1:
- Install BPF/XDP objects as non-executable to keep their symbol table from being stripped (only tested on openSUSE's build system though)
- Support GCC 7 and earlier
- Add a minimum version requirement for libbpf