### PR TITLE
libxdp: Allow creation of xsk with exclusive umem without CAP_NET_RAW

### DIFF
--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -229,6 +229,11 @@ int xsk_umem__create(struct xsk_umem **umem,
 		     struct xsk_ring_prod *fill,
 		     struct xsk_ring_cons *comp,
 		     const struct xsk_umem_config *config);
+int xsk_umem__create_with_fd(struct xsk_umem **umem,
+			     int fd, void *umem_area, __u64 size,
+			     struct xsk_ring_prod *fill,
+			     struct xsk_ring_cons *comp,
+			     const struct xsk_umem_config *config);
 int xsk_socket__create(struct xsk_socket **xsk,
 		       const char *ifname, __u32 queue_id,
 		       struct xsk_umem *umem,

--- a/lib/libxdp/README.org
+++ b/lib/libxdp/README.org
@@ -265,12 +265,22 @@ libxdp_flags field (also called libbpf_flags for compatibility
 reasons). This will make libxdp not load any XDP program or set and
 BPF maps which is a must if users want to add their own XDP program.
 
+If there is already a socket created with socket(AF_XDP, SOCK_RAW, 0)
+not bound and not tied to any umem, file descriptor of this socket can
+be used in an xsk_umem__create_with_fd() variant of the umem creation
+function.
+
 #+begin_src C
 int xsk_umem__create(struct xsk_umem **umem,
 		     void *umem_area, __u64 size,
 		     struct xsk_ring_prod *fill,
 		     struct xsk_ring_cons *comp,
 		     const struct xsk_umem_config *config);
+int xsk_umem__create_with_fd(struct xsk_umem **umem,
+			     int fd, void *umem_area, __u64 size,
+			     struct xsk_ring_prod *fill,
+			     struct xsk_ring_cons *comp,
+			     const struct xsk_umem_config *config);
 int xsk_socket__create(struct xsk_socket **xsk,
 		       const char *ifname, __u32 queue_id,
 		       struct xsk_umem *umem,
@@ -311,6 +321,12 @@ https://github.com/xdp-project/bpf-examples/tree/master/AF_XDP-example.
 int xsk_setup_xdp_prog(int ifindex, int *xsks_map_fd);
 int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
 #+end_src
+
+To further reduce required level of privileges, an AF_XDP socket can be created
+beforehand with socket(AF_XDP, SOCK_RAW, 0) and passed to a non-privileged
+process.  This socket can be used in xsk_umem__create_with_fd() and later
+in xsk_socket__create() with created umem.  xsk_socket__create_shared() would
+still require privileges for AF_XDP socket creation.
 
 ** Data path
 

--- a/lib/libxdp/libxdp.3
+++ b/lib/libxdp/libxdp.3
@@ -298,6 +298,12 @@ libxdp_flags field (also called libbpf_flags for compatibility
 reasons). This will make libxdp not load any XDP program or set and
 BPF maps which is a must if users want to add their own XDP program.
 
+.PP
+If there is already a socket created with socket(AF_XDP, SOCK_RAW, 0)
+not bound and not tied to any umem, file descriptor of this socket can
+be used in an xsk_umem__create_with_fd() variant of the umem creation
+function.
+
 .RS
 .nf
 \fCint xsk_umem__create(struct xsk_umem **umem,
@@ -355,6 +361,13 @@ int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
 \fP
 .fi
 .RE
+
+.PP
+To further reduce required level of privileges, an AF_XDP socket can be created
+beforehand with socket(AF_XDP, SOCK_RAW, 0) and passed to a non-privileged
+process.  This socket can be used in xsk_umem__create_with_fd() and later
+in xsk_socket__create() with created umem.  xsk_socket__create_shared() would
+still require privileges for AF_XDP socket creation.
 
 .SS "Data path"
 .PP

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -76,3 +76,7 @@ LIBXDP_1.3.0 {
 		xdp_program__test_run;
 		xdp_program__xdp_frags_support;
 } LIBXDP_1.2.0;
+
+LIBXDP_1.4.0 {
+		xsk_umem__create_with_fd;
+} LIBXDP_1.3.0;


### PR DESCRIPTION
Adding a new API xsk_umem__create_with_fd() that accepts an extra file descriptor of already open AF_XDP socket.  This function can be used as a substitute of a regular xsk_umem__create() in case where process doesn't have CAP_NET_RAW privileges.  Privileged process may open a socket beforehand and send the file descriptor via UNIX domain socket or pass it during exec().  Subsequent xsk_socket__create() will re-use this socket.  No other operations require privileges in case the program load is inhibited.

This change allows use of AF_XDP with libxdp by processes with no extra privileges.

xsk_socket__create_shared() requires opening a new socket for each queue after the first one, so it will require more work in order to create a pretty API.  Not doing that right now.  The target use-case is AF_XDP network backend in QEMU that doesn't need shared umem, but requires running without any privileges.