### PR TITLE
xdp-trafficgen: Cast argument to getsockname() to struct sockaddr

### DIFF
--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -790,7 +790,7 @@ int do_tcp(const void *opt, __unused const char *pin_root_path)
 	}
 
 	sockaddr_sz = sizeof(local_saddr);
-	err = getsockname(sock, &local_saddr, &sockaddr_sz);
+	err = getsockname(sock, (struct sockaddr *)&local_saddr, &sockaddr_sz);
 	if (err) {
 		err = -errno;
 		pr_warn("Couldn't get local address: %s\n", strerror(-err));


### PR DESCRIPTION
The must C library doesn't have the fancy union define that glibc has for
the various sockaddr structs, so it barfs on the use of a sockaddr_in6 as
an argument to getsockname(). Add an explicit cast to avoid the error.

Fixes #346