### PR TITLE
xdp-bench: flushing outputs after writing stats

### DIFF
--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -1192,6 +1192,10 @@ static void stats_print(const char *prefix, int mask, struct stats_record *r,
 		sample_err_exp = false;
 		printf("\n");
 	}
+
+	fflush(stdout);
+	fflush(stderr);
+	// Flushing both outputs to "bypass" buffering
 }
 
 static int get_num_rxqs(const char *ifname)


### PR DESCRIPTION
Having buffering enabled (by default in linux) for `stdout` causes issues for pipes. Since pipe buffer is pretty large (64KiB) it would take ages to fill that up. Therefore, applications in pipe are "unable" to reliably read `xdp-bench`'s `stdout`.

This approach may affect performance, but since `xdp-bench` tool does not rely on `stdout`/`stderr` operations, it's safe to flush both `stdout` and `stderr` buffers immediately.


#### Tests

before:
```python
>>> import time
>>> import subprocess as s
>>> p = s.Popen("xdp-bench drop eno12399", stdout=s.PIPE, stderr=s.PIPE, shell=True)  # piped back to python process
>>> time.sleep(15)
>>> p.kill()
>>> p.communicate()
(b'', b'Dropping packets on eno12399 (ifindex 4; driver ice)\n')  # (stdout, stderr)
>>>
```

after:  
```python
>>> import subprocess as s
>>> import time
>>> p = s.Popen("xdp-bench drop eno12399", stdout=s.PIPE, stderr=s.PIPE, shell=True)  # piped back to python process
>>> time.sleep(15)
>>> p.kill()
>>> p.communicate()
(b'Summary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \nSummary                         0 rx/s                  0 err/s        \n', b'Dropping packets on eno12399 (ifindex 4; driver ice)\n')  # (stdout, stderr)
>>>
```


Closes https://github.com/xdp-project/xdp-tools/issues/344