### PR TITLE
Support GCC compilation of BPF objects

### DIFF
--- a/configure
+++ b/configure
@@ -78,18 +78,6 @@ check_toolchain()
         fi;
     done
 
-    clang_version=$($CLANG --version | grep -Po '(?<=clang version )[[:digit:]]+')
-    if [ "$?" -ne "0" ]; then
-        echo "*** ERROR: Couldn't execute '$CLANG --version'"
-        exit 1
-    fi
-
-    echo "Found clang binary '$CLANG' with version $clang_version (from '$($CLANG --version | head -n 1)')"
-    if [ "$clang_version" -lt "11" ]; then
-        echo "*** ERROR: Need LLVM version 11+, '$CLANG' is version $clang_version"
-        [ -n "$RELAXED_LLVM_VERSION" ] || exit 1
-    fi
-
     if ! command -v $EMACS >/dev/null 2>&1; then
         EMACS=""
     else

--- a/headers/xdp/parsing_helpers.h
+++ b/headers/xdp/parsing_helpers.h
@@ -82,7 +82,7 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 	__u16 h_proto;
 	int i;
 
-	if (eth + 1 > data_end)
+	if ((void*)(eth + 1) > data_end)
 		return -1;
 
 	nh->pos = eth + 1;
@@ -93,12 +93,12 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 	/* Use loop unrolling to avoid the verifier restriction on loops;
 	 * support up to VLAN_MAX_DEPTH layers of VLAN encapsulation.
 	 */
-	#pragma unroll
+	#pragma GCC unroll 4
 	for (i = 0; i < VLAN_MAX_DEPTH; i++) {
 		if (!proto_is_vlan(h_proto))
 			break;
 
-		if (vlh + 1 > data_end)
+		if ((void*)(vlh + 1) > data_end)
 			break;
 
 		h_proto = vlh->h_vlan_encapsulated_proto;
@@ -116,7 +116,7 @@ static __always_inline int skip_ip6hdrext(struct hdr_cursor *nh,
 	for (int i = 0; i < IPV6_EXT_MAX_CHAIN; ++i) {
 		struct ipv6_opt_hdr *hdr = nh->pos;
 
-		if (hdr + 1 > data_end)
+		if ((void*)(hdr + 1) > data_end)
 			return -1;
 
 		switch (next_hdr_type) {
@@ -154,7 +154,7 @@ static __always_inline int parse_ip6hdr(struct hdr_cursor *nh,
 	 * thing being pointed to. We will be using this style in the remainder
 	 * of the tutorial.
 	 */
-	if (ip6h + 1 > data_end)
+	if ((void*)(ip6h + 1) > data_end)
 		return -1;
 
 	nh->pos = ip6h + 1;
@@ -170,13 +170,13 @@ static __always_inline int parse_iphdr(struct hdr_cursor *nh,
 	struct iphdr *iph = nh->pos;
 	int hdrsize;
 
-	if (iph + 1 > data_end)
+	if ((void*)(iph + 1) > data_end)
 		return -1;
 
 	hdrsize = iph->ihl * 4;
 
 	/* Variable-length IPv4 header, need to use byte-based arithmetic */
-	if (nh->pos + hdrsize > data_end)
+	if ((void*)(nh->pos + hdrsize) > data_end)
 		return -1;
 
 	nh->pos += hdrsize;
@@ -191,7 +191,7 @@ static __always_inline int parse_icmp6hdr(struct hdr_cursor *nh,
 {
 	struct icmp6hdr *icmp6h = nh->pos;
 
-	if (icmp6h + 1 > data_end)
+	if ((void*)(icmp6h + 1) > data_end)
 		return -1;
 
 	nh->pos   = icmp6h + 1;
@@ -206,7 +206,7 @@ static __always_inline int parse_icmphdr(struct hdr_cursor *nh,
 {
 	struct icmphdr *icmph = nh->pos;
 
-	if (icmph + 1 > data_end)
+	if ((void*)(icmph + 1) > data_end)
 		return -1;
 
 	nh->pos  = icmph + 1;
@@ -221,7 +221,7 @@ static __always_inline int parse_icmphdr_common(struct hdr_cursor *nh,
 {
 	struct icmphdr_common *h = nh->pos;
 
-	if (h + 1 > data_end)
+	if ((void*)(h + 1) > data_end)
 		return -1;
 
 	nh->pos  = h + 1;
@@ -240,7 +240,7 @@ static __always_inline int parse_udphdr(struct hdr_cursor *nh,
 	int len;
 	struct udphdr *h = nh->pos;
 
-	if (h + 1 > data_end)
+	if ((void*)(h + 1) > data_end)
 		return -1;
 
 	nh->pos  = h + 1;
@@ -263,11 +263,11 @@ static __always_inline int parse_tcphdr(struct hdr_cursor *nh,
 	int len;
 	struct tcphdr *h = nh->pos;
 
-	if (h + 1 > data_end)
+	if ((void*)(h + 1) > data_end)
 		return -1;
 
 	len = h->doff * 4;
-	if ((void *) h + len > data_end)
+	if ((void *)h + len > data_end)
 		return -1;
 
 	nh->pos  = h + 1;

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -109,7 +109,6 @@ $(ALL_EXEC_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OB
 
 $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -118,7 +117,7 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -o $@ ${@:.o=.ll}
 
 $(BPF_SKEL_H): %.skel.h: %.bpf.o
 	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< name ${@:.skel.h=} > $@

--- a/lib/defines.mk
+++ b/lib/defines.mk
@@ -1,5 +1,5 @@
 CFLAGS ?= -O2 -g
-BPF_CFLAGS ?= -Wno-visibility -fno-stack-protector
+BPF_CFLAGS ?= -Wno-visibility -fno-stack-protector -D BPF_NO_PRESERVE_ACCESS_INDEX -gbtf -mco-re
 BPF_TARGET ?= bpf
 
 HAVE_FEATURES :=

--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -27,7 +27,7 @@ PC_FILE := $(OBJDIR)/libxdp.pc
 TEMPLATED_SOURCES := xdp-dispatcher.c
 
 CFLAGS += -I$(HEADER_DIR)
-BPF_CFLAGS += -I$(HEADER_DIR)
+BPF_CFLAGS += -I$(HEADER_DIR) $(ARCH_INCLUDES)
 
 
 ifndef BUILD_STATIC_ONLY
@@ -135,7 +135,6 @@ $(EMBEDDED_XDP_OBJS): %.embed.o: %.o
 
 $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -144,7 +143,7 @@ $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -o $@ ${@:.o=.ll}
 
 .PHONY: man
 ifeq ($(EMACS),)

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -71,7 +71,6 @@ $(ALL_EXEC_TARGETS): %: %.c  $(OBJECT_LIBBPF) $(OBJECT_LIBXDP) $(LIBMK) $(LIB_OB
 
 $(BPF_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK) $(EXTRA_DEPS)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -80,7 +79,7 @@ $(BPF_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK) $(EXTRA_DEPS)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -o $@ ${@:.o=.ll}
 
 run: all
 	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" V=$(V) $(TEST_RUNNER) $(TEST_FILE) $(RUN_TESTS)

--- a/lib/util/Makefile
+++ b/lib/util/Makefile
@@ -19,7 +19,6 @@ BPF_CFLAGS += -I$(HEADER_DIR) $(ARCH_INCLUDES)
 
 $(UTIL_BPF_OBJS): %.o: %.c $(KERN_USER_H) $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_CLANG)$(CLANG) -S \
-	    -target $(BPF_TARGET) \
 	    -D __BPF_TRACING__ \
 	    $(BPF_CFLAGS) \
 	    -Wall \
@@ -28,7 +27,7 @@ $(UTIL_BPF_OBJS): %.o: %.c $(KERN_USER_H) $(BPF_HEADERS) $(LIBMK)
 	    -Wno-compare-distinct-pointer-types \
 	    -Werror \
 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+	$(QUIET_LLC)$(LLC) -o $@ ${@:.o=.ll}
 
 $(UTIL_SKEL_H): %.skel.h: %.bpf.o
 	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< name ${@:.skel.h=} > $@

--- a/xdp-bench/hash_func01.h
+++ b/xdp-bench/hash_func01.h
@@ -7,8 +7,9 @@
 #define get16bits(d) (*((const __u16 *) (d)))
 
 static __always_inline
-__u32 SuperFastHash(const char *data, int len, __u32 initval) {
+__u32 SuperFastHash4(const char *data, __u32 initval) {
 	__u32 hash = initval;
+	int len = 4;
 	__u32 tmp;
 	int rem;
 
@@ -18,7 +19,7 @@ __u32 SuperFastHash(const char *data, int len, __u32 initval) {
 	len >>= 2;
 
 	/* Main loop */
-#pragma clang loop unroll(full)
+#pragma GCC unroll 4
 	for (;len > 0; len--) {
 		hash  += get16bits (data);
 		tmp    = (get16bits (data+2) << 11) ^ hash;

--- a/xdp-bench/xdp_redirect_cpumap.bpf.c
+++ b/xdp-bench/xdp_redirect_cpumap.bpf.c
@@ -103,13 +103,13 @@ __u16 get_dest_port_ipv4_udp(struct xdp_md *ctx, __u64 nh_off)
 	struct iphdr *iph = data + nh_off;
 	struct udphdr *udph;
 
-	if (iph + 1 > data_end)
+	if ((void*)(iph + 1) > data_end)
 		return 0;
 	if (!(iph->protocol == IPPROTO_UDP))
 		return 0;
 
 	udph = (void *)(iph + 1);
-	if (udph + 1 > data_end)
+	if ((void*)(udph + 1) > data_end)
 		return 0;
 
 	return bpf_ntohs(udph->dest);
@@ -122,7 +122,7 @@ int get_proto_ipv4(struct xdp_md *ctx, __u64 nh_off)
 	void *data     = (void *)(long)ctx->data;
 	struct iphdr *iph = data + nh_off;
 
-	if (iph + 1 > data_end)
+	if ((void*)(iph + 1) > data_end)
 		return 0;
 	return iph->protocol;
 }
@@ -134,7 +134,7 @@ int get_proto_ipv6(struct xdp_md *ctx, __u64 nh_off)
 	void *data     = (void *)(long)ctx->data;
 	struct ipv6hdr *ip6h = data + nh_off;
 
-	if (ip6h + 1 > data_end)
+	if ((void*)(ip6h + 1) > data_end)
 		return 0;
 	return ip6h->nexthdr;
 }
@@ -186,7 +186,7 @@ int  cpumap_touch_data(struct xdp_md *ctx)
 	cpu_dest = *cpu_selected;
 
 	/* Validate packet length is minimum Eth header size */
-	if (eth + 1 > data_end)
+	if ((void*)(eth + 1) > data_end)
 		return XDP_ABORTED;
 
 	rec = bpf_map_lookup_elem(&rx_cnt, &key);
@@ -401,11 +401,11 @@ __u32 get_ipv4_hash_ip_pair(struct xdp_md *ctx, __u64 nh_off)
 	struct iphdr *iph = data + nh_off;
 	__u32 cpu_hash;
 
-	if (iph + 1 > data_end)
+	if ((void*)(iph + 1) > data_end)
 		return 0;
 
 	cpu_hash = iph->saddr + iph->daddr;
-	cpu_hash = SuperFastHash((char *)&cpu_hash, 4, INITVAL + iph->protocol);
+	cpu_hash = SuperFastHash4((char *)&cpu_hash, INITVAL + iph->protocol);
 
 	return cpu_hash;
 }
@@ -418,14 +418,14 @@ __u32 get_ipv6_hash_ip_pair(struct xdp_md *ctx, __u64 nh_off)
 	struct ipv6hdr *ip6h = data + nh_off;
 	__u32 cpu_hash;
 
-	if (ip6h + 1 > data_end)
+	if ((void*)(ip6h + 1) > data_end)
 		return 0;
 
 	cpu_hash  = ip6h->saddr.in6_u.u6_addr32[0] + ip6h->daddr.in6_u.u6_addr32[0];
 	cpu_hash += ip6h->saddr.in6_u.u6_addr32[1] + ip6h->daddr.in6_u.u6_addr32[1];
 	cpu_hash += ip6h->saddr.in6_u.u6_addr32[2] + ip6h->daddr.in6_u.u6_addr32[2];
 	cpu_hash += ip6h->saddr.in6_u.u6_addr32[3] + ip6h->daddr.in6_u.u6_addr32[3];
-	cpu_hash = SuperFastHash((char *)&cpu_hash, 4, INITVAL + ip6h->nexthdr);
+	cpu_hash = SuperFastHash4((char *)&cpu_hash, INITVAL + ip6h->nexthdr);
 
 	return cpu_hash;
 }

--- a/xdp-trafficgen/xdp_trafficgen.bpf.c
+++ b/xdp-trafficgen/xdp_trafficgen.bpf.c
@@ -84,7 +84,7 @@ int xdp_redirect_update_port(struct xdp_md *ctx)
 	__u32 key = 0;
 
 	hdr = data + (sizeof(struct ethhdr) + sizeof(struct ipv6hdr));
-	if (hdr + 1 > data_end)
+	if ((void*)(hdr + 1) > data_end)
 		goto out;
 
 	state = bpf_map_lookup_elem(&state_map, &key);
@@ -265,7 +265,7 @@ int xdp_redirect_send_tcp(struct xdp_md *ctx)
 
 	ipv6hdr = data + sizeof(struct ethhdr);
 	tcphdr = data + (sizeof(struct ethhdr) + sizeof(struct ipv6hdr));
-	if (tcphdr + 1 > data_end || ipv6hdr + 1 > data_end)
+	if ((void*)(tcphdr + 1) > data_end || (void*)(ipv6hdr + 1) > data_end)
 		goto ret;
 
 	pkt_len = bpf_ntohs(ipv6hdr->payload_len) - sizeof(*tcphdr);


### PR DESCRIPTION
This is currently just a messy dump off all changes required, with no regard of Clang compatibility. I intend refine into better shape in the future.

Configuration is done with

```
CLANG=bpf-none-gcc LLC=bpf-none-as PATH="$PATH:/sbin" ARCH_INCLUDES='-idirafter /usr/local/include -idirafter /usr/include' ./configure
```