### PR TITLE
Support detaching xdp_link-based attachments fix #361

### DIFF
--- a/lib/libxdp/tests/.gitignore
+++ b/lib/libxdp/tests/.gitignore
@@ -3,3 +3,4 @@ check_kern_compat
 test_xdp_frags
 test_dispatcher_versions
 test_xsk_non_privileged
+test_link_detach

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags test_dispatcher_versions
+USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags test_dispatcher_versions test_link_detach
 BPF_TARGETS := xdp_dispatcher_v1 xdp_pass
 USER_LIBS := -lpthread
 

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged"
+ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged test_link_detach"
 
 TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
@@ -102,9 +102,20 @@ test_xsk_non_privileged()
 	ip link delete xdp_veth0
 }
 
+test_link_detach()
+{
+        if test ! -f $TEST_PROG_DIR/test_link_detach; then
+		exit "$SKIPPED_TEST"
+	fi
+	ip link add xdp_veth0 type veth peer name xdp_veth1
+	check_run $TESTS_DIR/test_link_detach xdp_veth0
+	ip link delete xdp_veth0
+}
+
 cleanup_tests()
 {
     ip link del dev xdp_veth_big0 >/dev/null 2>&1
     ip link del dev xdp_veth_small0 >/dev/null 2>&1
     ip link del dev xsk_veth0 >/dev/null 2>&1
+    ip link del dev xdp_veth0 >/dev/null 2>&1
 }

--- a/lib/libxdp/tests/test_link_detach.c
+++ b/lib/libxdp/tests/test_link_detach.c
@@ -1,0 +1,112 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <linux/err.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+
+#include <xdp/libxdp.h>
+#include <bpf/libbpf.h>
+
+#define SKIPPED_TEST 249 // needs to match SKIPPED_TEST value in test_runner.sh
+
+static void usage(char *progname)
+{
+	fprintf(stderr, "Usage: %s <ifname>\n", progname);
+	exit(EXIT_FAILURE);
+}
+
+static int check_link_detach(int ifindex) {
+	struct bpf_object *obj_prog = NULL;
+	struct bpf_program *prog;
+	struct xdp_multiprog *mp = NULL;
+	struct bpf_link *link = NULL;
+	int ret;
+
+	if (!ifindex)
+		return -EINVAL;
+
+	obj_prog = bpf_object__open("xdp_pass.o");
+	if (!obj_prog) {
+		ret = -errno;
+		goto out;
+	}
+
+	prog = bpf_object__find_program_by_name(obj_prog, "xdp_pass");
+	if (!prog) {
+		ret = -errno;
+		goto out;
+	}
+
+
+	ret = bpf_object__load(obj_prog);
+	if (ret) {
+		ret = -errno;
+		fprintf(stderr, "Couldn't load object: %s\n", strerror(-ret));
+		goto out;
+	}
+
+	link = bpf_program__attach_xdp(prog, ifindex);
+	if (!link) {
+		ret = SKIPPED_TEST;
+		fprintf(stderr, "Couldn't attach XDP prog to ifindex %d: %s\n", ifindex, strerror(errno));
+		goto out;
+	}
+
+	mp = xdp_multiprog__get_from_ifindex(ifindex);
+	ret = libxdp_get_error(mp);
+	if (ret) {
+		fprintf(stderr, "Couldn't get multiprog on ifindex %d: %s\n",
+			ifindex, strerror(-ret));
+		goto out;
+	}
+
+	ret = xdp_multiprog__detach(mp);
+out:
+	bpf_link__destroy(link);
+	xdp_multiprog__close(mp);
+	bpf_object__close(obj_prog);
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	int ifindex;
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	char *envval;
+
+	envval = secure_getenv("VERBOSE_TESTS");
+
+	silence_libbpf_logging();
+	if (envval && envval[0] == '1')
+		verbose_libxdp_logging();
+	else
+		silence_libxdp_logging();
+
+	if (argc != 2)
+		usage(argv[0]);
+
+	ifindex = if_nametoindex(argv[1]);
+	if (!ifindex) {
+		fprintf(stderr, "Interface '%s' not found.\n", argv[1]);
+		usage(argv[0]);
+	}
+
+	return check_link_detach(ifindex);
+}


### PR DESCRIPTION
supporting force detach for link based attachments using `xdp-loader unload -a <intf>` fixes #361 