### PR TITLE
need to support xdp detach link for skb and native modes

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -3299,7 +3299,7 @@ static int xdp_multiprog__attach(struct xdp_multiprog *old_mp,
 
 	err = xdp_attach_fd(prog_fd, old_fd, ifindex, mode);
 	if (err < 0) {
-		if (errno == EBUSY && !mp && mode == XDP_MODE_NATIVE) {
+		if (errno == EBUSY && !mp) {
 			pr_debug("Detaching link on ifindex %d\n", ifindex);
 			return xdp_detach_link(ifindex, xdp_multiprog__main_id(old_mp));
 		}


### PR DESCRIPTION
we need to be able to handle skb and native modes to avoid this
```sh
# xdp-loader unload -a bond0
Unable to detach XDP program: Device or resource busy

# xdp-loader status
CURRENT XDP PROGRAM STATUS:

Interface        Prio  Program name      Mode     ID   Tag               Chain actions
--------------------------------------------------------------------------------------
lo                     <No XDP program loaded!>
eno1                   <No XDP program loaded!>
eno2                   <No XDP program loaded!>
ens5f0                 <No XDP program loaded!>
ens5f1                 <No XDP program loaded!>
gre0                   <No XDP program loaded!>
gretap0                <No XDP program loaded!>
erspan0                <No XDP program loaded!>
ovs-system             <No XDP program loaded!>
genev_sys_6081         <No XDP program loaded!>
br-int                 <No XDP program loaded!>
ovn-k8s-mp0            <No XDP program loaded!>
bond0                  ingress_node_firewall_process skb      2    26d19a2050b4db60 
```