### PR TITLE
xdp-bench: Add l4-sport and l4-dport cpumap modes

### DIFF
--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -356,6 +356,8 @@ redirected to different CPUs. The following options are available:
  l4-proto		- Choose the target CPU based on the layer-4 protocol of packet
  l4-filter		- Like l4-proto, but drop UDP packets with destination port 9 (used by pktgen)
  l4-hash		- Use source and destination IP hashing to pick target CPU
+ l4-sport		- Use modulo of source port to pick target CPU
+ l4-dport		- Use modulo of destination port to pick target CPU
 #+end_src
 
 The =no-touch= and =touch= modes always redirect packets to the same CPU (the

--- a/xdp-bench/xdp-bench.c
+++ b/xdp-bench/xdp-bench.c
@@ -63,6 +63,8 @@ struct enum_val cpumap_program_modes[] = {
        {"l4-proto", CPUMAP_CPU_L4_PROTO},
        {"l4-filter", CPUMAP_CPU_L4_PROTO_FILTER},
        {"l4-hash", CPUMAP_CPU_L4_HASH},
+       {"l4-sport", CPUMAP_CPU_L4_SPORT},
+       {"l4-dport", CPUMAP_CPU_L4_DPORT},
        {NULL, 0}
 };
 

--- a/xdp-bench/xdp-bench.h
+++ b/xdp-bench/xdp-bench.h
@@ -80,6 +80,8 @@ enum cpumap_program_mode {
 	CPUMAP_CPU_L4_PROTO,
 	CPUMAP_CPU_L4_PROTO_FILTER,
 	CPUMAP_CPU_L4_HASH,
+	CPUMAP_CPU_L4_SPORT,
+	CPUMAP_CPU_L4_DPORT,
 };
 
 struct cpumap_opts {

--- a/xdp-bench/xdp_redirect_cpumap.c
+++ b/xdp-bench/xdp_redirect_cpumap.c
@@ -50,6 +50,8 @@ static const char *cpumap_prog_names[] = {
 	"cpumap_l4_proto",
 	"cpumap_l4_filter",
 	"cpumap_l4_hash",
+	"cpumap_l4_sport",
+	"cpumap_l4_dport",
 };
 
 DEFINE_SAMPLE_INIT(xdp_redirect_cpumap);


### PR DESCRIPTION
These modes assigns CPUs based on L4 source and dest port. This is useful for load testing scenarios where you can assign sequential source ports to flows (like with neper).

For router/gateway use cases you use sport mapping on the forward direction and dport mapping on the reverse direction.