### PR TITLE
libxdp: Fix xdp prog memory leak in xsk_setup_xdp_prog

### DIFF
--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -978,6 +978,7 @@ static struct xsk_ctx *xsk_create_ctx(struct xsk_socket *xsk,
 
 static void xsk_destroy_xsk_struct(struct xsk_socket *xsk)
 {
+	xdp_program__close(xsk->ctx->xdp_prog);
 	free(xsk->ctx);
 	free(xsk);
 }


### PR DESCRIPTION
In the xsk_setup_xdp_prog function, the xsk structure temporarily takes ownership of an xdp_prog and stores it in ctx->xdp_prog. However, the allocated xdp_prog is not freed in xsk_destroy_xsk_struct, leading to a memory leak. This commit addresses the issue by adding a call to xdp_program__close to properly release the allocated xdp_prog memory.