### PR TITLE
Added support for clang-17 in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ find_tool()
 
     # we're looking for a binary with the same name as tool_name; try version
     # suffixes in order until we find one
-    for v in 16 15 14 13 12 11; do
+    for v in 17 16 15 14 13 12 11; do
         tool_path="${tool_name}-$v"
         if command -v "$tool_path" >/dev/null 2>&1; then
             echo $tool_path


### PR DESCRIPTION
Hello!

I hope you're doing well.

Thank you very much for working on this code.

I recently did build with clang-17 from https://apt.llvm.org/ and it uses name of binary with suffix "-17": clang-17 which is not supported by configure script.

I added 17 as possible suffix for clang compiler name. 
