### PR TITLE
Fix transposed calloc() arguments

### DIFF
--- a/lib/util/params.c
+++ b/lib/util/params.c
@@ -248,7 +248,7 @@ static int handle_ifname_multi(char *optarg, void *tgt, __unused struct prog_opt
 	if (ifindex < 0)
 		return ifindex;
 
-	iface = calloc(sizeof(*iface), 1);
+	iface = calloc(1, sizeof(*iface));
 	if (!iface)
 		return -ENOMEM;
 

--- a/lib/util/xpcapng.c
+++ b/lib/util/xpcapng.c
@@ -226,7 +226,7 @@ static bool pcapng_write_shb(struct xpcapng_dumper *pd, const char *comment,
 	shb_length += sizeof(uint32_t);
 
 	/* Allocate the SHB and fill it. */
-	shb = calloc(shb_length, 1);
+	shb = calloc(1, shb_length);
 	if (shb == NULL) {
 		errno = ENOMEM;
 		return false;
@@ -318,7 +318,7 @@ static bool pcapng_write_idb(struct xpcapng_dumper *pd, const char *name,
 	idb_length += sizeof(uint32_t);
 
 	/* Allocate the IDB and fill it. */
-	idb = calloc(idb_length, 1);
+	idb = calloc(1, idb_length);
 	if (idb == NULL) {
 		errno = ENOMEM;
 		return false;
@@ -549,7 +549,7 @@ struct xpcapng_dumper *xpcapng_dump_open(const char *file,
 		goto error_exit;
 	}
 
-	pd = calloc(sizeof(*pd), 1);
+	pd = calloc(1, sizeof(*pd));
 	if (pd == NULL) {
 		errno = ENOMEM;
 		goto error_exit;

--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -197,13 +197,13 @@ static int create_runners(pthread_t **runner_threads, struct thread_config **thr
 	pthread_t *threads;
 	int i, err;
 
-	threads = calloc(sizeof(pthread_t), num_threads);
+	threads = calloc(num_threads, sizeof(pthread_t));
 	if (!threads) {
 		pr_warn("Couldn't allocate memory\n");
 		return -ENOMEM;
 	}
 
-	t = calloc(sizeof(struct thread_config), num_threads);
+	t = calloc(num_threads, sizeof(struct thread_config));
 	if (!t) {
 		pr_warn("Couldn't allocate memory\n");
 		free(threads);


### PR DESCRIPTION
Calls to calloc() are supposed to have the number of elements as the first
argument, but we erroneously transposed the arguments in a couple of places. It
seems GCC 14 has started to warn about this, which exposed this as build
breakage.

Fixes #387