### PR TITLE
xdp-bench: Add support for xdp_buff with empty linear part

### DIFF
--- a/xdp-bench/tests/test-xdp-bench.sh
+++ b/xdp-bench/tests/test-xdp-bench.sh
@@ -36,6 +36,7 @@ test_xdp_load_bytes()
 
     for action in drop pass tx; do
         check_run $XDP_BENCH $action $NS -p parse-ip -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -p read-data -l load-bytes -vv
     done
 }
 

--- a/xdp-bench/tests/test-xdp-bench.sh
+++ b/xdp-bench/tests/test-xdp-bench.sh
@@ -37,6 +37,7 @@ test_xdp_load_bytes()
     for action in drop pass tx; do
         check_run $XDP_BENCH $action $NS -p parse-ip -l load-bytes -vv
         check_run $XDP_BENCH $action $NS -p read-data -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -p swap-macs -l load-bytes -vv
     done
 }
 

--- a/xdp-bench/xdp_basic.bpf.c
+++ b/xdp-bench/xdp_basic.bpf.c
@@ -119,15 +119,6 @@ static int record_stats(__u32 rxq_idx, bool success)
 SEC("xdp")
 int xdp_basic_prog(struct xdp_md *ctx)
 {
-	void *data_end = (void *)(long)ctx->data_end;
-	void *data = (void *)(long)ctx->data;
-	struct ethhdr *eth = data;
-	__u64 nh_off;
-
-	nh_off = sizeof(*eth);
-	if (data + nh_off > data_end)
-		return XDP_ABORTED;
-
 	if (record_stats(ctx->rx_queue_index, true))
 		return XDP_ABORTED;
 

--- a/xdp-bench/xdp_basic.bpf.c
+++ b/xdp-bench/xdp_basic.bpf.c
@@ -148,6 +148,26 @@ int xdp_read_data_prog(struct xdp_md *ctx)
 }
 
 SEC("xdp")
+int xdp_read_data_load_bytes_prog(struct xdp_md *ctx)
+{
+	int err, offset = 0;
+	struct ethhdr eth;
+	int ret = action;
+
+	err = bpf_xdp_load_bytes(ctx, offset, &eth, sizeof(eth));
+	if (err)
+		return err;
+
+	if (bpf_ntohs(eth.h_proto) < ETH_P_802_3_MIN)
+		ret = XDP_ABORTED;
+
+	if (record_stats(ctx->rx_queue_index, ret==action))
+		return XDP_ABORTED;
+
+	return ret;
+}
+
+SEC("xdp")
 int xdp_swap_macs_prog(struct xdp_md *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;

--- a/xdp-bench/xdp_basic.bpf.c
+++ b/xdp-bench/xdp_basic.bpf.c
@@ -201,15 +201,7 @@ int xdp_parse_prog(struct xdp_md *ctx)
 SEC("xdp")
 int xdp_parse_load_bytes_prog(struct xdp_md *ctx)
 {
-	void *data_end = (void *)(long)ctx->data_end;
-	void *data = (void *)(long)ctx->data;
-	struct ethhdr *eth = data;
 	int ret = action;
-	__u64 nh_off;
-
-	nh_off = sizeof(*eth);
-	if (data + nh_off > data_end)
-		return XDP_ABORTED;
 
 	if (parse_ip_header_load(ctx))
 		ret = XDP_ABORTED;

--- a/xdp-bench/xdp_basic.c
+++ b/xdp-bench/xdp_basic.c
@@ -71,8 +71,8 @@ static int do_basic(const struct basic_opts *opt, enum xdp_action action)
 		mask |= SAMPLE_RXQ_STATS;
 	}
 
-	if (opt->load_mode == BASIC_LOAD_BYTES && opt->program_mode != BASIC_PARSE_IPHDR) {
-		pr_warn("Setting '-l load-bytes' only works with '-p parse-ip'\n");
+	if (opt->load_mode == BASIC_LOAD_BYTES && opt->program_mode == BASIC_SWAP_MACS) {
+		pr_warn("Setting '-l load-bytes' doesn't work with '-p swap-macs'\n");
 		ret = EXIT_FAIL_BPF;
 		goto end_destroy;
 	}
@@ -88,7 +88,7 @@ static int do_basic(const struct basic_opts *opt, enum xdp_action action)
 		opts.prog_name = "xdp_basic_prog";
 		break;
 	case BASIC_READ_DATA:
-		opts.prog_name = "xdp_read_data_prog";
+		opts.prog_name = (opt->load_mode == BASIC_LOAD_BYTES) ? "xdp_read_data_load_bytes_prog" : "xdp_read_data_prog";
 		break;
 	case BASIC_PARSE_IPHDR:
 		opts.prog_name = (opt->load_mode == BASIC_LOAD_BYTES) ? "xdp_parse_load_bytes_prog" : "xdp_parse_prog";

--- a/xdp-bench/xdp_basic.c
+++ b/xdp-bench/xdp_basic.c
@@ -71,12 +71,6 @@ static int do_basic(const struct basic_opts *opt, enum xdp_action action)
 		mask |= SAMPLE_RXQ_STATS;
 	}
 
-	if (opt->load_mode == BASIC_LOAD_BYTES && opt->program_mode == BASIC_SWAP_MACS) {
-		pr_warn("Setting '-l load-bytes' doesn't work with '-p swap-macs'\n");
-		ret = EXIT_FAIL_BPF;
-		goto end_destroy;
-	}
-
 	/* Make sure we only load the one XDP program we are interested in */
 	while ((prog = bpf_object__next_program(skel->obj, prog)) != NULL)
 		if (bpf_program__type(prog) == BPF_PROG_TYPE_XDP &&
@@ -94,7 +88,7 @@ static int do_basic(const struct basic_opts *opt, enum xdp_action action)
 		opts.prog_name = (opt->load_mode == BASIC_LOAD_BYTES) ? "xdp_parse_load_bytes_prog" : "xdp_parse_prog";
 		break;
 	case BASIC_SWAP_MACS:
-		opts.prog_name = "xdp_swap_macs_prog";
+		opts.prog_name = (opt->load_mode == BASIC_LOAD_BYTES) ? "xdp_swap_macs_load_bytes_prog" : "xdp_swap_macs_prog";
 		break;
 	}
 


### PR DESCRIPTION
In some network driver implementations, the linear part of the xdp_buff structure might be empty, with all data stored in the frags section. Accessing packet data directly is impossible in this case, and requires an API like the bpf_xdp_load/store_bytes helpers or dynptr.

This pull request ensures support for all xdp-bench packet operations (swap-macs, read-data, etc.) of basic actions (DROP, PASS, TX) when the linear part is empty.

The next step is to extend this functionality to the REDIRECT actions and explore integration with other tools beyond xdp-bench. After that, the plan is to introduce the option to use the superior dynptr API as another packet access alternative.