### PR TITLE
xdp-bench: Fix packet-operation values in documentation

### DIFF
--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -66,7 +66,7 @@ following actions are available:
 
 #+begin_src sh
  no-touch		- Drop the packet without touching the packet data
- touch		- Read a field in the packet header before dropping
+ read-data		- Read a field in the packet header before dropping
  parse-ip		- Parse the IP header field before dropping
  swap-macs		- Swap the source and destination MAC addresses before dropping
 #+end_src
@@ -146,7 +146,7 @@ following actions are available:
 
 #+begin_src sh
  no-touch		- Pass the packet without touching the packet data
- touch		- Read a field in the packet header before passing
+ read-data		- Read a field in the packet header before passing
  parse-ip		- Parse the IP header field before passing
  swap-macs		- Swap the source and destination MAC addresses before passing
 #+end_src
@@ -221,7 +221,7 @@ following actions are available:
 
 #+begin_src sh
  no-touch		- Transmit the packet without touching the packet data
- touch		- Read a field in the packet header before transmitting
+ read-data		- Read a field in the packet header before transmitting
  parse-ip		- Parse the IP header field before transmitting
  swap-macs		- Swap the source and destination MAC addresses before transmitting
 #+end_src

--- a/xdp-bench/xdp-bench.8
+++ b/xdp-bench/xdp-bench.8
@@ -75,7 +75,7 @@ following actions are available:
 .RS
 .nf
 \fCno-touch		- Drop the packet without touching the packet data
-touch		- Read a field in the packet header before dropping
+read-data		- Read a field in the packet header before dropping
 parse-ip		- Parse the IP header field before dropping
 swap-macs		- Swap the source and destination MAC addresses before dropping
 \fP
@@ -179,7 +179,7 @@ following actions are available:
 .RS
 .nf
 \fCno-touch		- Pass the packet without touching the packet data
-touch		- Read a field in the packet header before passing
+read-data		- Read a field in the packet header before passing
 parse-ip		- Parse the IP header field before passing
 swap-macs		- Swap the source and destination MAC addresses before passing
 \fP
@@ -277,7 +277,7 @@ following actions are available:
 .RS
 .nf
 \fCno-touch		- Transmit the packet without touching the packet data
-touch		- Read a field in the packet header before transmitting
+read-data		- Read a field in the packet header before transmitting
 parse-ip		- Parse the IP header field before transmitting
 swap-macs		- Swap the source and destination MAC addresses before transmitting
 \fP


### PR DESCRIPTION
Update the readme and manpage to match the values in xdp-bench.c.