### PR TITLE
xdp-dump: add check for new promiscuous mode message in tests

### DIFF
--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -448,11 +448,11 @@ test_promiscuous_selfload()
     fi
 
     RESULT=$(dmesg)
-    if [[ "$RESULT" != *"device $NS entered promiscuous mode"* ]]; then
+    if [[ "$RESULT" != *"device $NS entered promiscuous mode"* ]] && [[ "$RESULT" != *"$NS: entered promiscuous mode"* ]]; then
         print_result "Failed enabling promiscuous mode on legacy interface"
         return 1
     fi
-    if [[ "$RESULT" != *"device $NS left promiscuous mode"* ]]; then
+    if [[ "$RESULT" != *"device $NS left promiscuous mode"* ]] && [[ "$RESULT" != *"$NS: left promiscuous mode"* ]]; then
         print_result "Failed disabling promiscuous mode on legacy interface"
         return 1
     fi
@@ -477,11 +477,11 @@ test_promiscuous_preload()
     fi
 
     RESULT=$(dmesg)
-    if [[ "$RESULT" != *"device $NS entered promiscuous mode"* ]]; then
+    if [[ "$RESULT" != *"device $NS entered promiscuous mode"* ]] && [[ "$RESULT" != *"$NS: entered promiscuous mode"* ]]; then
         print_result "Failed enabling promiscuous mode on interface"
         return 1
     fi
-    if [[ "$RESULT" != *"device $NS left promiscuous mode"* ]]; then
+    if [[ "$RESULT" != *"device $NS left promiscuous mode"* ]] && [[ "$RESULT" != *"$NS: left promiscuous mode"* ]]; then
         print_result "Failed disabling promiscuous mode on interface"
         return 1
     fi


### PR DESCRIPTION
kernel updated the promiscuous mode message in below commit, so update the previous check condition.

net/core: refactor promiscuous mode message

old message:
[  406.034418] device eth0 entered promiscuous mode 
[  408.424703] device eth0 left promiscuous mode

new message:
[  406.034431] ice 0000:17:00.0 eth0: entered promiscuous mode 
[  408.424715] ice 0000:17:00.0 eth0: left promiscuous mode