### PR TITLE
xdp-forward: Introduce xdp-fwd-flowtable support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include config.mk
 UTILS := xdp-filter xdp-loader xdp-dump
 
 ifneq ($(BPFTOOL),)
-UTILS += xdp-bench xdp-monitor xdp-trafficgen
+UTILS += xdp-bench xdp-forward xdp-monitor xdp-trafficgen
 endif
 
 SUBDIRS := lib $(UTILS)

--- a/headers/linux/hlist.h
+++ b/headers/linux/hlist.h
@@ -5,6 +5,10 @@
 
 struct list_head;
 
+struct rhash_head {
+	struct rhash_head *next;
+};
+
 #define HLIST_POISON_POINTER_DELTA 0
 #define HLIST_POISON1  ((void *) 0x100 + HLIST_POISON_POINTER_DELTA)
 #define HLIST_POISON2  ((void *) 0x200 + HLIST_POISON_POINTER_DELTA)

--- a/headers/linux/netfilter.h
+++ b/headers/linux/netfilter.h
@@ -1,0 +1,114 @@
+#ifndef _LINUX_NETFILTER_H
+#define _LINUX_NETFILTER_H
+
+#include <stdbool.h>
+#include <linux/types.h>
+#include <bpf/bpf_helpers.h>
+#include <xdp/parsing_helpers.h>
+
+#include "hlist.h"
+
+struct flow_ports {
+	__be16 source, dest;
+};
+
+enum ip_conntrack_dir {
+	IP_CT_DIR_ORIGINAL,
+	IP_CT_DIR_REPLY,
+	IP_CT_DIR_MAX
+};
+
+enum flow_offload_tuple_dir {
+	FLOW_OFFLOAD_DIR_ORIGINAL = IP_CT_DIR_ORIGINAL,
+	FLOW_OFFLOAD_DIR_REPLY = IP_CT_DIR_REPLY,
+};
+#define FLOW_OFFLOAD_DIR_MAX	IP_CT_DIR_MAX
+
+enum flow_offload_type {
+	NF_FLOW_OFFLOAD_UNSPEC,
+	NF_FLOW_OFFLOAD_ROUTE,
+};
+
+enum nf_flow_flags {
+	NF_FLOW_SNAT,
+	NF_FLOW_DNAT,
+	NF_FLOW_TEARDOWN,
+	NF_FLOW_HW,
+	NF_FLOW_HW_DYING,
+	NF_FLOW_HW_DEAD,
+	NF_FLOW_HW_PENDING,
+	NF_FLOW_HW_BIDIRECTIONAL,
+	NF_FLOW_HW_ESTABLISHED,
+};
+
+enum flow_offload_xmit_type {
+	FLOW_OFFLOAD_XMIT_UNSPEC,
+	FLOW_OFFLOAD_XMIT_NEIGH,
+	FLOW_OFFLOAD_XMIT_XFRM,
+	FLOW_OFFLOAD_XMIT_DIRECT,
+	FLOW_OFFLOAD_XMIT_TC,
+};
+
+#define NF_FLOW_TABLE_ENCAP_MAX		2
+struct flow_offload_tuple {
+	union {
+		struct in_addr		src_v4;
+		struct in6_addr		src_v6;
+	};
+	union {
+		struct in_addr		dst_v4;
+		struct in6_addr		dst_v6;
+	};
+	struct {
+		__be16			src_port;
+		__be16			dst_port;
+	};
+
+	int				iifidx;
+
+	__u8				l3proto;
+	__u8				l4proto;
+	struct {
+		__u16			id;
+		__be16			proto;
+	} encap[NF_FLOW_TABLE_ENCAP_MAX];
+
+	/* All members above are keys for lookups, see flow_offload_hash(). */
+	struct { }			__hash;
+
+	__u8				dir:2,
+					xmit_type:3,
+					encap_num:2,
+					in_vlan_ingress:2;
+	__u16				mtu;
+	union {
+		struct {
+			struct dst_entry *dst_cache;
+			__u32		dst_cookie;
+		};
+		struct {
+			__u32		ifidx;
+			__u32		hw_ifidx;
+			__u8		h_source[ETH_ALEN];
+			__u8		h_dest[ETH_ALEN];
+		} out;
+		struct {
+			__u32		iifidx;
+		} tc;
+	};
+};
+
+struct flow_offload_tuple_rhash {
+	struct rhash_head		node;
+	struct flow_offload_tuple	tuple;
+};
+
+struct flow_offload {
+	struct flow_offload_tuple_rhash		tuplehash[FLOW_OFFLOAD_DIR_MAX];
+	struct nf_conn				*ct;
+	unsigned long				flags;
+	__u16					type;
+	__u32					timeout;
+};
+
+#endif /* _LINUX_NETFILTER_H */

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -139,5 +139,5 @@ test:
 	@echo "    No tests defined"
 else
 test: all
-	$(Q)$(TEST_DIR)/test_runner.sh $(TEST_FILE)
+	$(Q)$(TEST_DIR)/test_runner.sh $(TEST_FILE) $(TESTS)
 endif

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -460,7 +460,7 @@ usage()
 
 if [ "$EUID" -ne "0" ]; then
     if command -v sudo >/dev/null 2>&1; then
-        exec sudo env V=${VERBOSE_TESTS} "$0" "$@"
+        exec sudo env V=${VERBOSE_TESTS} DEBUG_TESTENV=${DEBUG_TESTENV:-0} "$0" "$@"
     else
         die "Tests should be run as root"
     fi
@@ -487,4 +487,10 @@ TOOL_TESTS_DIR="$(dirname "$TEST_DEFINITIONS")"
 shift
 trap teardown EXIT
 setup
+
+if [ "${DEBUG_TESTENV:-0}" -eq "1" ] && [ -n "$SHELL" ]; then
+    echo "Entering interactive testenv debug - Ctrl-D to exit and resume test execution"
+    $SHELL
+fi
+
 run_tests "$@"

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -584,6 +584,9 @@ fi
 
 export XDP_FILTER
 export XDP_LOADER
+export XDP_BENCH
+export XDP_MONITOR
+export XDP_TRAFFICGEN
 export XDPDUMP
 
 TEST_DEFINITIONS="${1:-}"

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -8,7 +8,6 @@
 # Date:     26 May 2020
 # Copyright (c) 2020 Red Hat
 
-set -o errexit
 set -o nounset
 umask 077
 
@@ -343,6 +342,8 @@ setup()
 {
     local nsname
 
+    set -o errexit
+
     check_prereq
 
     for i in $(seq $NUM_NS); do
@@ -350,6 +351,8 @@ setup()
         init_ns $nsname $i
         NS_NAMES+=($nsname)
     done
+
+    set +o errexit
 
     NS=$nsname
 }

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -309,8 +309,8 @@ init_ns()
     ip link add dev "$nsname" type veth peer name "$peername"
     set_sysctls $nsname
 
-    ethtool -K "$nsname" rxvlan off txvlan off
-    ethtool -K "$peername" rxvlan off txvlan off
+    ethtool -K "$nsname" rxvlan off txvlan off gro on
+    ethtool -K "$peername" rxvlan off txvlan off gro on
 
     OUTSIDE_MAC=$(iface_macaddr "$nsname")
     INSIDE_MAC=$(iface_macaddr "$peername")

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -242,6 +242,8 @@ check_prereq()
     if [ "$max_locked_mem" != "unlimited" ]; then
 	ulimit -l unlimited || die "Unable to set ulimit"
     fi
+
+    mount -t bpf bpf /sys/fs/bpf/ || die "Unable to mount bpffs"
 }
 
 gen_nsname()
@@ -300,10 +302,6 @@ init_ns()
     INSIDE_IP4="${IP4_PREFIX}2"
     OUTSIDE_IP6="${IP6_PREFIX}1"
     OUTSIDE_IP4="${IP4_PREFIX}1"
-
-    if ! mount | grep -q /sys/fs/bpf; then
-        mount -t bpf bpf /sys/fs/bpf/
-    fi
 
     ip netns add "$nsname"
     ip link add dev "$nsname" type veth peer name "$peername"

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -580,6 +580,11 @@ if [ "$EUID" -ne "0" ]; then
     else
         die "Tests should be run as root"
     fi
+else
+    if [ "${DID_UNSHARE:-0}" -ne "1" ]; then
+        echo "    Executing tests in separate net- and mount namespaces" >&2
+        exec env DID_UNSHARE=1 unshare -n -m "$0" "$@"
+    fi
 fi
 
 export XDP_FILTER

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -21,13 +21,12 @@ IP6_FULL_PREFIX_SIZE=48 # Size of IP6_SUBNET
 IP4_SUBNET=10.11
 IP4_PREFIX_SIZE=24 # Size of assigned prefixes
 IP4_FULL_PREFIX_SIZE=16 # Size of IP4_SUBNET
-VLAN_IDS=(1 2)
 GENERATED_NAME_PREFIX="xdptest"
 ALL_TESTS=""
 VERBOSE_TESTS=${V:-0}
+NUM_NS=2
 
 NEEDED_TOOLS="capinfos ethtool ip ping sed tc tcpdump timeout nc tshark"
-MAX_NAMELEN=15
 
 if [ -f "$TEST_CONFIG" ]; then
     source "$TEST_CONFIG"
@@ -43,21 +42,11 @@ fi
 SKIPPED_TEST=249
 
 # Global state variables that will be set by options etc below
-GENERATE_NEW=0
-CLEANUP_FUNC=
 STATEDIR=
-STATEFILE=
 CMD=
 NS=
-LEGACY_IP=1
-USE_VLAN=0
-RUN_ON_INNER=0
+NS_NAMES=()
 
-# State variables that are written to and read from statefile
-STATEVARS=(IP6_PREFIX IP4_PREFIX
-           INSIDE_IP6 INSIDE_IP4 INSIDE_MAC
-           OUTSIDE_IP6 OUTSIDE_IP4 OUTSIDE_MAC
-           ENABLE_IPV4 ENABLE_VLAN)
 IP6_PREFIX=
 IP4_PREFIX=
 INSIDE_IP6=
@@ -66,8 +55,8 @@ INSIDE_MAC=
 OUTSIDE_IP6=
 OUTSIDE_IP4=
 OUTSIDE_MAC=
-ENABLE_IPV4=0
-ENABLE_VLAN=0
+ALL_INSIDE_IP6=()
+ALL_INSIDE_IP4=()
 
 is_trace_attach_supported()
 {
@@ -207,8 +196,6 @@ start_background_no_stderr()
 
 start_background_ns_devnull()
 {
-    get_nsname && ensure_nsname "$NS"
-
     local TMP_FILE="${STATEDIR}/tmp_proc_$$_$RANDOM"
     setsid ip netns exec "$NS" env TESTENV_NAME="$NS" "$SETUP_SCRIPT" bash -c "$*" 1>/dev/null 2>${TMP_FILE} &
     local PID=$!
@@ -257,93 +244,17 @@ check_prereq()
     fi
 }
 
-get_nsname()
+gen_nsname()
 {
-    local GENERATE=${1:-1}
+    local nsname
 
-    if [ -z "$NS" ]; then
-        [ -f "$STATEDIR/current" ] && NS=$(< "$STATEDIR/current")
+    while
+        nsname=$(printf "%s-%04x" "$GENERATED_NAME_PREFIX" $RANDOM)
+        [ -e "$STATEDIR/${nsname}.ns" ]
+    do true; done
 
-        if [ "$GENERATE" -eq "1" ] && [ -z "$NS" ] || [ "$GENERATE_NEW" -eq "1" ]; then
-            NS="$GENERATED_NAME_PREFIX"
-            while [ -e "$STATEDIR/${NS}.state" ]; do
-                NS=$(printf "%s-%04x" "$GENERATED_NAME_PREFIX" $RANDOM)
-            done
-        fi
-    fi
-
-    if [ "${#NS}" -gt "$MAX_NAMELEN" ]; then
-        die "Environment name '$NS' is too long (max $MAX_NAMELEN)"
-    fi
-
-    STATEFILE="$STATEDIR/${NS}.state"
-}
-
-ensure_nsname()
-{
-    [ -z "$NS" ] && die "No environment selected; use --name to select one or 'setup' to create one"
-    [ -e "$STATEFILE" ] || die "Environment for $NS doesn't seem to exist"
-
-    echo "$NS" > "$STATEDIR/current"
-
-    read_statefile
-}
-
-get_num()
-{
-    local num=1
-    if [ -f "$STATEDIR/highest_num" ]; then
-        num=$(( 1 + $(< "$STATEDIR/highest_num" )))
-    fi
-
-    echo $num > "$STATEDIR/highest_num"
-    printf "%x" $num
-}
-
-write_statefile()
-{
-    [ -z "$STATEFILE" ] && return 1
-    echo > "$STATEFILE"
-    for var in "${STATEVARS[@]}"; do
-        echo "${var}='$(eval echo '$'$var)'" >> "$STATEFILE"
-    done
-}
-
-read_statefile()
-{
-    local value
-    for var in "${STATEVARS[@]}"; do
-        value=$(source "$STATEFILE"; eval echo '$'$var)
-        eval "$var=\"$value\""
-    done
-}
-
-cleanup_setup()
-{
-    echo "Error during setup, removing partially-configured environment '$NS'" >&2
-    set +o errexit
-    ip netns del "$NS" 2>/dev/null
-    ip link del dev "$NS" 2>/dev/null
-    rm -f "$STATEFILE"
-}
-
-cleanup_teardown()
-{
-    echo "Warning: Errors during teardown, partial environment may be left" >&2
-}
-
-
-cleanup()
-{
-    [ -n "$CLEANUP_FUNC" ] && $CLEANUP_FUNC
-
-    local statefiles=("$STATEDIR"/*.state)
-
-    if [ "${#statefiles[*]}" -eq 1 ] && [ ! -e "${statefiles[0]}" ]; then
-        rm -f "${STATEDIR}/highest_num" "${STATEDIR}/current" \
-           "${STATEDIR}/trace_attach_support"
-        rmdir "$STATEDIR"
-    fi
+    touch "$STATEDIR/${nsname}.ns"
+    echo $nsname
 }
 
 iface_macaddr()
@@ -369,119 +280,90 @@ set_sysctls()
     done
 }
 
-get_vlan_prefix()
+init_ns()
 {
-    # Split the IPv6 prefix, and add the VLAN ID to the upper byte of the fourth
-    # element in the prefix. This will break if the global prefix config doesn't
-    # have exactly three elements in it.
-    local prefix="$1"
-    local vid="$2"
-    (IFS=:; set -- $prefix; printf "%s:%s:%s:%x::" "$1" "$2" "$3" $(($4 + $vid * 4096)))
-}
+    local nsname=$1
+    local num=$2
+    local peername="testl-ve-$num"
 
-setup()
-{
-    get_nsname 1
-
-    [ -e "$STATEFILE" ] && die "Environment for '$NS' already exists"
-
-    local NUM=$(get_num "$NS")
-    local PEERNAME="testl-ve-$NUM"
-    [ -z "$IP6_PREFIX" ] && IP6_PREFIX="${IP6_SUBNET}:${NUM}::"
-    [ -z "$IP4_PREFIX" ] && IP4_PREFIX="${IP4_SUBNET}.$((0x$NUM))."
+    IP6_PREFIX="${IP6_SUBNET}:${num}::"
+    IP4_PREFIX="${IP4_SUBNET}.$((0x$num))."
 
     INSIDE_IP6="${IP6_PREFIX}2"
     INSIDE_IP4="${IP4_PREFIX}2"
     OUTSIDE_IP6="${IP6_PREFIX}1"
     OUTSIDE_IP4="${IP4_PREFIX}1"
 
-    CLEANUP_FUNC=cleanup_setup
-
     if ! mount | grep -q /sys/fs/bpf; then
         mount -t bpf bpf /sys/fs/bpf/
     fi
 
-    ip netns add "$NS"
-    ip link add dev "$NS" type veth peer name "$PEERNAME"
-    OUTSIDE_MAC=$(iface_macaddr "$NS")
-    INSIDE_MAC=$(iface_macaddr "$PEERNAME")
-    set_sysctls $NS
+    ip netns add "$nsname"
+    ip link add dev "$nsname" type veth peer name "$peername"
+    set_sysctls $nsname
 
-    ethtool -K "$NS" rxvlan off txvlan off
-    ethtool -K "$PEERNAME" rxvlan off txvlan off
-    ip link set dev "$PEERNAME" netns "$NS"
-    ip link set dev "$NS" up
-    ip addr add dev "$NS" "${OUTSIDE_IP6}/${IP6_PREFIX_SIZE}"
+    ethtool -K "$nsname" rxvlan off txvlan off
+    ethtool -K "$peername" rxvlan off txvlan off
 
-    ip -n "$NS" link set dev "$PEERNAME" name veth0
-    ip -n "$NS" link set dev lo up
-    ip -n "$NS" link set dev veth0 up
-    set_sysctls veth0 "$NS"
-    ip -n "$NS" addr add dev veth0 "${INSIDE_IP6}/${IP6_PREFIX_SIZE}"
+    OUTSIDE_MAC=$(iface_macaddr "$nsname")
+    INSIDE_MAC=$(iface_macaddr "$peername")
+    ip link set dev "$peername" netns "$nsname"
+    ip link set dev "$nsname" up
+    ip addr add dev "$nsname" "${OUTSIDE_IP6}/${IP6_PREFIX_SIZE}"
+
+    ip -n "$nsname" link set dev "$peername" name veth0
+    ip -n "$nsname" link set dev lo up
+    ip -n "$nsname" link set dev veth0 up
+    set_sysctls veth0 "$nsname"
+    ip -n "$nsname" addr add dev veth0 "${INSIDE_IP6}/${IP6_PREFIX_SIZE}"
 
     # Prevent neighbour queries on the link
-    ip neigh add "$INSIDE_IP6" lladdr "$INSIDE_MAC" dev "$NS" nud permanent
-    ip -n "$NS" neigh add "$OUTSIDE_IP6" lladdr "$OUTSIDE_MAC" dev veth0 nud permanent
+    ip neigh add "$INSIDE_IP6" lladdr "$INSIDE_MAC" dev "$nsname" nud permanent
+    ip -n "$nsname" neigh add "$OUTSIDE_IP6" lladdr "$OUTSIDE_MAC" dev veth0 nud permanent
 
-    # Add route for whole test subnet, to make it easier to communicate between
-    # namespaces
-    ip -n "$NS" route add "${IP6_SUBNET}::/$IP6_FULL_PREFIX_SIZE" via "$OUTSIDE_IP6" dev veth0
+    ip addr add dev "$nsname" "${OUTSIDE_IP4}/${IP4_PREFIX_SIZE}"
+    ip -n "$nsname" addr add dev veth0 "${INSIDE_IP4}/${IP4_PREFIX_SIZE}"
+    ip neigh add "$INSIDE_IP4" lladdr "$INSIDE_MAC" dev "$nsname" nud permanent
+    ip -n "$nsname" neigh add "$OUTSIDE_IP4" lladdr "$OUTSIDE_MAC" dev veth0 nud permanent
 
-    if [ "$LEGACY_IP" -eq "1" ]; then
-        ip addr add dev "$NS" "${OUTSIDE_IP4}/${IP4_PREFIX_SIZE}"
-        ip -n "$NS" addr add dev veth0 "${INSIDE_IP4}/${IP4_PREFIX_SIZE}"
-        ip neigh add "$INSIDE_IP4" lladdr "$INSIDE_MAC" dev "$NS" nud permanent
-        ip -n "$NS" neigh add "$OUTSIDE_IP4" lladdr "$OUTSIDE_MAC" dev veth0 nud permanent
-        ip -n "$NS" route add "${IP4_SUBNET}/${IP4_FULL_PREFIX_SIZE}" via "$OUTSIDE_IP4" dev veth0
-        ENABLE_IPV4=1
-    else
-        ENABLE_IPV4=0
-    fi
+    # Add default routes inside the ns
+    ip -n "$nsname" route add default dev veth0
+    ip -n "$nsname" -6 route add default dev veth0
 
-    if [ "$USE_VLAN" -eq "1" ]; then
-        ENABLE_VLAN=1
-        for vid in "${VLAN_IDS[@]}"; do
-            local vlpx="$(get_vlan_prefix "$IP6_PREFIX" "$vid")"
-            local inside_ip="${vlpx}2"
-            local outside_ip="${vlpx}1"
-            ip link add dev "${NS}.$vid" link "$NS" type vlan id "$vid"
-            ip link set dev "${NS}.$vid" up
-            ip addr add dev "${NS}.$vid" "${outside_ip}/${IP6_PREFIX_SIZE}"
-            ip neigh add "$inside_ip" lladdr "$INSIDE_MAC" dev "${NS}.$vid" nud permanent
-            set_sysctls "${NS}/$vid"
+    ALL_INSIDE_IP4+=($INSIDE_IP4)
+    ALL_INSIDE_IP6+=($INSIDE_IP6)
+}
 
-            ip -n "$NS" link add dev "veth0.$vid" link "veth0" type vlan id "$vid"
-            ip -n "$NS" link set dev "veth0.$vid" up
-            ip -n "$NS" addr add dev "veth0.$vid" "${inside_ip}/${IP6_PREFIX_SIZE}"
-            ip -n "$NS" neigh add "$outside_ip" lladdr "$OUTSIDE_MAC" dev "veth0.$vid" nud permanent
-            set_sysctls "veth0/$vid" "$NS"
-        done
-    else
-        ENABLE_VLAN=0
-    fi
+setup()
+{
+    local nsname
 
-    write_statefile
+    check_prereq
 
-    CLEANUP_FUNC=
+    for i in $(seq $NUM_NS); do
+        nsname=$(gen_nsname)
+        init_ns $nsname $i
+        NS_NAMES+=($nsname)
+    done
 
-    echo "$NS" > "$STATEDIR/current"
+    NS=$nsname
+}
+
+teardown_ns()
+{
+    local nsname=$1
+
+    ip link del dev "$nsname"
+    ip netns del "$nsname"
+    [ -d "/sys/fs/bpf/$nsname" ] && rmdir "/sys/fs/bpf/$nsname" || true
+
 }
 
 teardown()
 {
-    get_nsname && ensure_nsname "$NS"
-
-    CLEANUP_FUNC=cleanup_teardown
-
-    ip link del dev "$NS"
-    ip netns del "$NS"
-    rm -f "$STATEFILE"
-    [ -d "/sys/fs/bpf/$NS" ] && rmdir "/sys/fs/bpf/$NS" || true
-
-    if [ -f "$STATEDIR/current" ]; then
-        local CUR=$(< "$STATEDIR/current" )
-        [[ "$CUR" == "$NS" ]] && rm -f "$STATEDIR/current"
-    fi
+    for ns in "${NS_NAMES[@]}"; do
+        teardown_ns $ns
+    done
 
     for f in ${STATEDIR}/proc/*; do
         if [ -f "$f" ]; then
@@ -491,14 +373,10 @@ teardown()
     done
 
     rm -rf "$STATEDIR"
-
-    CLEANUP_FUNC=
 }
 
 ns_exec()
 {
-    get_nsname && ensure_nsname "$NS"
-
     ip netns exec "$NS" env TESTENV_NAME="$NS" "$SETUP_SCRIPT" "$@"
 }
 
@@ -554,7 +432,6 @@ run_tests()
     local TESTS="$*"
     local ret=0
     [ -z "$TESTS" ] && TESTS="$ALL_TESTS"
-    setup || return 1
 
     echo "    Running tests from $TEST_DEFINITIONS"
 
@@ -602,5 +479,5 @@ TOOL_TESTS_DIR="$(dirname "$TEST_DEFINITIONS")"
 
 shift
 trap teardown EXIT
-check_prereq
+setup
 run_tests "$@"

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -149,7 +149,7 @@ test_capt_pcapng()
     INFOS_REGEX+="Capture hardware:    $HW.*"
     INFOS_REGEX+="Capture oper-sys:    $OS.*"
     INFOS_REGEX+="Capture application: xdpdump v[0-9]+\.[0-9]+\.[0-9]+.*"
-    INFOS_REGEX+="Capture comment:     Capture was taken on interface xdptest, with the following XDP programs loaded:   xdp_dispatcher\(\)     xdp_test_prog_w.*"
+    INFOS_REGEX+="Capture comment:     Capture was taken on interface $NS, with the following XDP programs loaded:   xdp_dispatcher\(\)     xdp_test_prog_w.*"
     INFOS_REGEX+="Interface #0 info:.*"
     INFOS_REGEX+="Name = ${NS}:xdp_test_prog_with_a_long_name\(\)@fentry.*"
     if [ $OLD_CAPINFOS -eq 0 ]; then
@@ -188,7 +188,7 @@ test_capt_pcapng()
     fi
 
     if version_greater_or_equal "$TSHARK_VERSION" 3.6.7; then
-	local ATTRIB_REGEX="^xdptest:xdp_test_prog_with_a_long_name\(\)@fentry	0	1	$.*^xdptest:xdp_test_prog_with_a_long_name\(\)@fexit	0	1	2$.*"
+	local ATTRIB_REGEX="^$NS:xdp_test_prog_with_a_long_name\(\)@fentry	0	1	$.*^$NS:xdp_test_prog_with_a_long_name\(\)@fexit	0	1	2$.*"
 	RESULT=$(tshark -r "$PCAP_FILE" -T fields \
 			-e frame.interface_name \
 			-e frame.interface_queue \
@@ -213,7 +213,7 @@ test_capt_term()
 
     local PASS_REGEX="(xdp_test_prog_with_a_long_name\(\)@entry: packet size 118 bytes on if_index [0-9]+, rx queue [0-9]+, id [0-9]+)"
     local PASS_X_REGEX="(xdp_test_prog_with_a_long_name\(\)@entry: packet size 118 bytes, captured 118 bytes on if_index [0-9]+, rx queue [0-9]+, id [0-9]+)"
-    local PASS_X_OPT="0x0020:  00 00 00 00 00 02 fc 42 de ad ca fe 00 01 00 00"
+    local PASS_X_OPT="0x0020:  00 00 00 00 00 02 fc 42 de ad ca fe"
 
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
 

--- a/xdp-forward/.gitignore
+++ b/xdp-forward/.gitignore
@@ -1,0 +1,1 @@
+xdp-forward

--- a/xdp-forward/Makefile
+++ b/xdp-forward/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+
+XDP_TARGETS := xdp_forward.bpf
+BPF_SKEL_TARGETS := $(XDP_TARGETS)
+
+XDP_OBJ_INSTALL :=
+
+TOOL_NAME := xdp-forward
+MAN_PAGE :=
+TEST_FILE :=
+USER_TARGETS := xdp-forward
+
+LIB_DIR := ../lib
+
+include $(LIB_DIR)/common.mk

--- a/xdp-forward/Makefile
+++ b/xdp-forward/Makefile
@@ -7,7 +7,7 @@ XDP_OBJ_INSTALL :=
 
 TOOL_NAME := xdp-forward
 MAN_PAGE := xdp-forward.8
-TEST_FILE :=
+TEST_FILE := tests/test-xdp-forward.sh
 USER_TARGETS := xdp-forward
 
 LIB_DIR := ../lib

--- a/xdp-forward/Makefile
+++ b/xdp-forward/Makefile
@@ -6,7 +6,7 @@ BPF_SKEL_TARGETS := $(XDP_TARGETS)
 XDP_OBJ_INSTALL :=
 
 TOOL_NAME := xdp-forward
-MAN_PAGE :=
+MAN_PAGE := xdp-forward.8
 TEST_FILE :=
 USER_TARGETS := xdp-forward
 

--- a/xdp-forward/README.org
+++ b/xdp-forward/README.org
@@ -1,0 +1,136 @@
+#+EXPORT_FILE_NAME: xdp-forward
+#+TITLE: xdp-forward
+#+OPTIONS: ^:nil
+#+MAN_CLASS_OPTIONS: :section-id "8\" \"DATE\" \"VERSION\" \"XDP program loader"
+# This file serves both as a README on github, and as the source for the man
+# page; the latter through the org-mode man page export support.
+# .
+# To export the man page, simply use the org-mode exporter; (require 'ox-man) if
+# it's not available. There's also a Makefile rule to export it.
+
+* xdp-forward - the XDP forwarding plane
+
+xdp-forward is an XDP forwarding plane, which will accelerate packet forwarding
+using XDP. To use it, simply load it on the set of interfaces to accelerate
+forwarding between. The userspace component of xdp-forward will then configure
+and load XDP programs on those interfaces, and forward packets between them
+using XDP_REDIRECT, using the kernel routing table to determine the destination
+if each packet.
+
+Any packets that xdp-forward does not know how to forward will be passed up to
+the networking stack and handled by the kernel like normal. Depending on the
+mode xdp-forward is loaded in, this leads to different forwarding behaviours.
+See the sectinon on *Operating modes* below.
+
+** Running xdp-forward
+The syntax for running xdp-forward is:
+
+#+begin_src sh
+xdp-forward COMMAND [options]
+
+Where COMMAND can be one of:
+       load        - Load the XDP forwarding plane
+       unload      - Unload the XDP forwarding plane
+       help        - show the list of available commands
+#+end_src
+
+Each command, and its options are explained below. Or use =xdp-forward COMMAND
+--help= to see the options for each command.
+
+* The LOAD command
+The =load= command loads the XDP forwarding plane on a list of interfaces.
+
+The syntax for the =load= command is:
+
+=xdp-forward load [options] <ifname...>=
+
+Where =<ifname...>= is the name of the set of interfaces to forward packets
+between. An XDP program will be loaded on each interface, configured to forward
+packets to all other interfaces in the set (using the kernel routing table to
+determine the destination interface of each packet).
+
+The supported options are:
+
+** -f, --fwd-mode <mode>
+Specifies which forwarding mode =xdp-forward= should operate in. Depending on
+the mode selected, =xdp-forward= will perform forwarding in different ways,
+which can lead to different behaviour, including which subset of kernel
+configuration (such as firewall rules) is respected during forwarding. See the
+section *OPERATING MODES* below for a full description of each mode.
+
+** -m, --mode <mode>
+Specifies which mode to load the XDP program to be loaded in. The valid values
+are 'native', which is the default in-driver XDP mode, 'skb', which causes the
+so-called /skb mode/ (also known as /generic XDP/) to be used, 'hw' which causes
+the program to be offloaded to the hardware, or 'unspecified' which leaves it up
+to the kernel to pick a mode (which it will do by picking native mode if the
+driver supports it, or generic mode otherwise). Note that using 'unspecified'
+can make it difficult to predict what mode a program will end up being loaded
+in. For this reason, the default is 'native'. Note that hardware with support
+for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
+only devices with support for this in the mainline Linux kernel.
+
+** -v, --verbose
+Enable debug logging. Specify twice for even more verbosity.
+
+** -h, --help
+Display a summary of the available options
+
+* The UNLOAD command
+The =unload= command is used for unloading programs from an interface.
+
+The syntax for the =unload= command is:
+
+=xdp-forward unload [options] <ifname...>=
+
+Where =<ifname...>= is the list of interfaces to unload the XDP forwarding plane
+from. Note that while =xdp-forward= will examine the XDP programs loaded on each
+interface and make sure to only unload its own program, it will not check that
+the list of supplied interfaces is the same as the one supplied during load. As
+such, it is possible to perform a partial unload by supplying a different list
+of interfaces, which may lead to unexpected behaviour.
+
+The supported options are:
+
+** -v, --verbose
+Enable debug logging. Specify twice for even more verbosity.
+
+** -h, --help
+Display a summary of the available options
+
+* OPERATING MODES
+The =xdp-forward= utility supports the following operating modes (selected by
+the =--fwd-mode= parameter to =xdp-forward load=.
+
+** fib-full (default)
+In the =fib-full= operating mode, =xdp-forward= will perform a full lookup in
+the kernel routing table (or FIB) for each packet, and forward packets between
+the configured interfaces based on the result of the lookup. Any packet where
+the lookup fails will be passed up to the stack. This includes packets that
+require neighbour discovery for the next hop, meaning that packets will
+periodically pass up the kernel stack for next hop discovery (initially, and
+when the nexthop entry expires).
+
+Note that no checks other than the FIB lookup is performed; in particular, this
+completely bypasses the netfilter subsystem, so firewall rules will not be
+checked before forwarding.
+
+** fib-direct
+The =fib-direct= mode functions like =fib-full=, except it passes the
+=BPF_FIB_LOOKUP_DIRECT= flag to the FIB lookup routine. This means that any
+policy routing rules configured will be skipped during the lookup, which can
+improve performance (but won't obey the policy of those rules, obviously).
+
+* SEE ALSO
+=libxdp(3)= for details on the XDP loading semantics and kernel compatibility
+requirements.
+
+* BUGS
+
+Please report any bugs on Github: https://github.com/xdp-project/xdp-tools/issues
+
+* AUTHOR
+
+xdp-forward is written by Toke Høiland-Jørgensen, based on the xdp_fwd kernel
+sample, which was originally written by David Ahern. This man page was written
+by Toke Høiland-Jørgensen.

--- a/xdp-forward/README.org
+++ b/xdp-forward/README.org
@@ -14,8 +14,8 @@ xdp-forward is an XDP forwarding plane, which will accelerate packet forwarding
 using XDP. To use it, simply load it on the set of interfaces to accelerate
 forwarding between. The userspace component of xdp-forward will then configure
 and load XDP programs on those interfaces, and forward packets between them
-using XDP_REDIRECT, using the kernel routing table to determine the destination
-if each packet.
+using XDP_REDIRECT, using the kernel routing table or netfilter flowtable to
+determine the destination for each packet.
 
 Any packets that xdp-forward does not know how to forward will be passed up to
 the networking stack and handled by the kernel like normal. Depending on the
@@ -120,6 +120,13 @@ The =fib-direct= mode functions like =fib-full=, except it passes the
 =BPF_FIB_LOOKUP_DIRECT= flag to the FIB lookup routine. This means that any
 policy routing rules configured will be skipped during the lookup, which can
 improve performance (but won't obey the policy of those rules, obviously).
+
+** flowtable
+The =flowtable= operating mode offloads netfilter sw flowtable logic in
+the XDP layer if the hardware flowtable is not available.
+At the moment =xdp-forward= is able to offload just TCP or UDP netfilter
+flowtable entries to XDP. The user is supposed to configure the flowtable
+separately.
 
 * SEE ALSO
 =libxdp(3)= for details on the XDP loading semantics and kernel compatibility

--- a/xdp-forward/tests/test-xdp-forward.sh
+++ b/xdp-forward/tests/test-xdp-forward.sh
@@ -1,0 +1,59 @@
+XDP_LOADER=${XDP_LOADER:-./xdp-loader}
+XDP_FORWARD=${XDP_FORWARD:-./xdp-forward}
+ALL_TESTS="test_ping test_load test_fwd_full test_fwd_direct"
+
+
+test_ping()
+{
+    for ip in "${ALL_INSIDE_IP4[@]}"; do
+        check_run ping -c 1 -W 2 $ip
+        check_run ns_exec ping -c 1 -W 2 $ip
+    done
+    for ip in "${ALL_INSIDE_IP6[@]}"; do
+        check_run $PING6 -c 1 -W 2 $ip
+        check_run ns_exec $PING6 -c 1 -W 2 $ip
+    done
+}
+
+test_load()
+{
+
+    check_run $XDP_FORWARD load ${NS_NAMES[@]}
+    check_run $XDP_FORWARD unload ${NS_NAMES[@]}
+}
+
+test_fwd_full()
+{
+    # veth NAPI GRO support added this symbol; forwarding won't work without it
+    skip_if_missing_kernel_symbol veth_set_features
+
+    check_run $XDP_FORWARD load -f fib-full ${NS_NAMES[@]}
+    for ip in "${ALL_INSIDE_IP4[@]}"; do
+        check_run ns_exec ping -c 1 -W 2 $ip
+    done
+    for ip in "${ALL_INSIDE_IP4[@]}"; do
+        check_run ns_exec ping -c 1 -W 2 $ip
+    done
+    check_run $XDP_FORWARD unload ${NS_NAMES[@]}
+}
+
+test_fwd_direct()
+{
+    # veth NAPI GRO support added this symbol; forwarding won't work without it
+    skip_if_missing_kernel_symbol veth_set_features
+
+    check_run $XDP_FORWARD load -f fib-direct ${NS_NAMES[@]}
+    for ip in "${ALL_INSIDE_IP4[@]}"; do
+        check_run ns_exec ping -c 1 -W 2 $ip
+    done
+    for ip in "${ALL_INSIDE_IP4[@]}"; do
+        check_run ns_exec ping -c 1 -W 2 $ip
+    done
+    check_run $XDP_FORWARD unload ${NS_NAMES[@]}
+}
+
+cleanup_tests()
+{
+    $XDP_FORWARD unload ${NS_NAMES[@]} >/dev/null 2>&1
+    $XDP_LOADER unload $NS --all >/dev/null 2>&1
+}

--- a/xdp-forward/xdp-forward.8
+++ b/xdp-forward/xdp-forward.8
@@ -1,0 +1,133 @@
+.TH "xdp-forward" "8" "JULY 30, 2024" "V1.4.2" "XDP program loader"
+
+.SH "NAME"
+xdp-forward \- the XDP forwarding plane
+.SH "SYNOPSIS"
+.PP
+xdp-forward is an XDP forwarding plane, which will accelerate packet forwarding
+using XDP. To use it, simply load it on the set of interfaces to accelerate
+forwarding between. The userspace component of xdp-forward will then configure
+and load XDP programs on those interfaces, and forward packets between them
+using XDP_REDIRECT, using the kernel routing table to determine the destination
+if each packet.
+
+.PP
+Any packets that xdp-forward does not know how to forward will be passed up to
+the networking stack and handled by the kernel like normal. Depending on the
+mode xdp-forward is loaded in, this leads to different forwarding behaviours.
+See the sectinon on \fBOperating modes\fP below.
+
+.SS "Running xdp-forward"
+.PP
+The syntax for running xdp-forward is:
+
+.RS
+.nf
+\fCxdp-forward COMMAND [options]
+
+Where COMMAND can be one of:
+       load        - Load the XDP forwarding plane
+       unload      - Unload the XDP forwarding plane
+       help        - show the list of available commands
+\fP
+.fi
+.RE
+
+.PP
+Each command, and its options are explained below. Or use \fIxdp\-forward COMMAND
+\-\-help\fP to see the options for each command.
+
+.SH "The LOAD command"
+.PP
+The \fIload\fP command loads the XDP forwarding plane on a list of interfaces.
+
+.PP
+The syntax for the \fIload\fP command is:
+
+.PP
+\fIxdp\-forward load [options] <ifname...>\fP
+
+.PP
+Where \fI<ifname...>\fP is the name of the set of interfaces to forward packets
+between. An XDP program will be loaded on each interface, configured to forward
+packets to all other interfaces in the set (using the kernel routing table to
+determine the destination interface of each packet).
+
+.PP
+The supported options are:
+
+.SS "-f, --fwd-mode <mode>"
+.PP
+Specifies which forwarding mode \fIxdp\-forward\fP should operate in. Depending on
+the mode selected, \fIxdp\-forward\fP will perform forwarding in different ways,
+which can lead to different behaviour, including which subset of kernel
+configuration (such as firewall rules) is respected during forwarding. See the
+section \fBOPERATING MODES\fP below for a full description of each mode.
+
+.SS "-m, --mode <mode>"
+.PP
+Specifies which mode to load the XDP program to be loaded in. The valid values
+are 'native', which is the default in-driver XDP mode, 'skb', which causes the
+so-called \fIskb mode\fP (also known as \fIgeneric XDP\fP) to be used, 'hw' which causes
+the program to be offloaded to the hardware, or 'unspecified' which leaves it up
+to the kernel to pick a mode (which it will do by picking native mode if the
+driver supports it, or generic mode otherwise). Note that using 'unspecified'
+can make it difficult to predict what mode a program will end up being loaded
+in. For this reason, the default is 'native'. Note that hardware with support
+for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
+only devices with support for this in the mainline Linux kernel.
+
+.SS "-v, --verbose"
+.PP
+Enable debug logging. Specify twice for even more verbosity.
+
+.SS "-h, --help"
+.PP
+Display a summary of the available options
+
+.SH "The UNLOAD command"
+.PP
+The \fIunload\fP command is used for unloading programs from an interface.
+
+.PP
+The syntax for the \fIunload\fP command is:
+
+.PP
+\fIxdp\-forward unload [options] <ifname...>\fP
+
+.PP
+Where \fI<ifname...>\fP is the list of interfaces to unload the XDP forwarding plane
+from. Note that while \fIxdp\-forward\fP will examine the XDP programs loaded on each
+interface and make sure to only unload its own program, it will not check that
+the list of supplied interfaces is the same as the one supplied during load. As
+such, it is possible to perform a partial unload by supplying a different list
+of interfaces, which may lead to unexpected behaviour.
+
+.PP
+The supported options are:
+
+.SS "-v, --verbose"
+.PP
+Enable debug logging. Specify twice for even more verbosity.
+
+.SS "-h, --help"
+.PP
+Display a summary of the available options
+
+.SH "OPERATING MODES"
+nil
+
+.SH "SEE ALSO"
+.PP
+\fIlibxdp(3)\fP for details on the XDP loading semantics and kernel compatibility
+requirements.
+
+.SH "BUGS"
+.PP
+Please report any bugs on Github: \fIhttps://github.com/xdp-project/xdp-tools/issues\fP
+
+.SH "AUTHOR"
+.PP
+xdp-forward is written by Toke Høiland-Jørgensen, based on the xdp_fwd kernel
+sample, which was originally written by David Ahern. This man page was written
+by Toke Høiland-Jørgensen.

--- a/xdp-forward/xdp-forward.8
+++ b/xdp-forward/xdp-forward.8
@@ -8,8 +8,8 @@ xdp-forward is an XDP forwarding plane, which will accelerate packet forwarding
 using XDP. To use it, simply load it on the set of interfaces to accelerate
 forwarding between. The userspace component of xdp-forward will then configure
 and load XDP programs on those interfaces, and forward packets between them
-using XDP_REDIRECT, using the kernel routing table to determine the destination
-if each packet.
+using XDP_REDIRECT, using the kernel routing table or netfilter flowtable to
+determine the destination for each packet.
 
 .PP
 Any packets that xdp-forward does not know how to forward will be passed up to
@@ -140,6 +140,14 @@ The \fIfib\-direct\fP mode functions like \fIfib\-full\fP, except it passes the
 \fIBPF_FIB_LOOKUP_DIRECT\fP flag to the FIB lookup routine. This means that any
 policy routing rules configured will be skipped during the lookup, which can
 improve performance (but won't obey the policy of those rules, obviously).
+
+.SS "flowtable"
+.PP
+The \fIflowtable\fP operating mode offloads netfilter sw flowtable logic in the
+XDP layer if the hardware flowtable is not available.
+At the moment \fIxdp-forward\fP is able to offload just TCP or UDP netfilter
+flowtable entries to XDP. The user is supposed to configure the flowtable
+separately.
 
 .SH "SEE ALSO"
 .PP

--- a/xdp-forward/xdp-forward.8
+++ b/xdp-forward/xdp-forward.8
@@ -115,7 +115,31 @@ Enable debug logging. Specify twice for even more verbosity.
 Display a summary of the available options
 
 .SH "OPERATING MODES"
-nil
+.PP
+The \fIxdp\-forward\fP utility supports the following operating modes (selected by
+the \fI\-\-fwd\-mode\fP parameter to \fIxdp\-forward load\fP.
+
+.SS "fib-full (default)"
+.PP
+In the \fIfib\-full\fP operating mode, \fIxdp\-forward\fP will perform a full lookup in
+the kernel routing table (or FIB) for each packet, and forward packets between
+the configured interfaces based on the result of the lookup. Any packet where
+the lookup fails will be passed up to the stack. This includes packets that
+require neighbour discovery for the next hop, meaning that packets will
+periodically pass up the kernel stack for next hop discovery (initially, and
+when the nexthop entry expires).
+
+.PP
+Note that no checks other than the FIB lookup is performed; in particular, this
+completely bypasses the netfilter subsystem, so firewall rules will not be
+checked before forwarding.
+
+.SS "fib-direct"
+.PP
+The \fIfib\-direct\fP mode functions like \fIfib\-full\fP, except it passes the
+\fIBPF_FIB_LOOKUP_DIRECT\fP flag to the FIB lookup routine. This means that any
+policy routing rules configured will be skipped during the lookup, which can
+improve performance (but won't obey the policy of those rules, obviously).
 
 .SH "SEE ALSO"
 .PP

--- a/xdp-forward/xdp-forward.c
+++ b/xdp-forward/xdp-forward.c
@@ -1,0 +1,252 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+#include <xdp/libxdp.h>
+
+#include "params.h"
+#include "util.h"
+#include "logging.h"
+
+#include "xdp_forward.skel.h"
+
+#define MAX_IFACE_NUM 32
+#define PROG_NAME "xdp-forward"
+
+int do_help(__unused const void *cfg, __unused const char *pin_root_path)
+{
+	fprintf(stderr,
+		"Usage: xdp-forward COMMAND [options]\n"
+		"\n"
+		"COMMAND can be one of:\n"
+		"       load           - Load the XDP forwarding plane\n"
+		"       unload         - Unload the XDP forwarding plane\n"
+		"       help           - show this help message\n"
+		"\n"
+		"Use 'xdp-forward COMMAND --help' to see options for each command\n");
+	return -1;
+}
+
+
+struct enum_val xdp_modes[] = { { "native", XDP_MODE_NATIVE },
+				{ "skb", XDP_MODE_SKB },
+				{ NULL, 0 } };
+
+enum fwd_mode {
+	FWD_FIB_DIRECT,
+	FWD_FIB_FULL
+};
+
+struct enum_val fwd_modes[] = { { "fib-direct", FWD_FIB_DIRECT },
+				{ "fib-full", FWD_FIB_FULL },
+				{ NULL, 0 } };
+
+static int find_prog(struct iface *iface, bool detach)
+{
+	struct xdp_program *prog = NULL;
+	enum xdp_attach_mode mode;
+	struct xdp_multiprog *mp;
+	int ret = -ENOENT;
+
+	mp = xdp_multiprog__get_from_ifindex(iface->ifindex);
+	if (!mp)
+		return ret;
+
+	if (xdp_multiprog__is_legacy(mp)) {
+		prog = xdp_multiprog__main_prog(mp);
+		goto check;
+	}
+
+	while ((prog = xdp_multiprog__next_prog(prog, mp))) {
+	check:
+		if (!strcmp(xdp_program__name(prog), "xdp_fwd_fib_full") ||
+		    !strcmp(xdp_program__name(prog), "xdp_fwd_fib_direct")) {
+			mode = xdp_multiprog__attach_mode(mp);
+			ret = 0;
+			if (detach) {
+				ret = xdp_program__detach(prog, iface->ifindex,
+							  mode, 0);
+				if (ret)
+					pr_warn("Couldn't detach XDP program from interface %s: %s\n",
+						iface->ifname,
+						strerror(errno));
+				break;
+			}
+		}
+	}
+
+	xdp_multiprog__close(mp);
+	return ret;
+}
+
+struct load_opts {
+	enum fwd_mode fwd_mode;
+	enum xdp_attach_mode xdp_mode;
+	struct iface *ifaces;
+} defaults_load = { .fwd_mode = FWD_FIB_FULL };
+
+struct prog_option load_options[] = {
+	DEFINE_OPTION("fwd-mode", OPT_ENUM, struct load_opts, fwd_mode,
+		      .short_opt = 'f',
+		      .typearg = fwd_modes,
+		      .metavar = "<mode>",
+		      .help = "Forward mode to run in; see man page. Default fib-full"),
+	DEFINE_OPTION("xdp-mode", OPT_ENUM, struct load_opts, xdp_mode,
+		      .short_opt = 'm',
+		      .typearg = xdp_modes,
+		      .metavar = "<xdp_mode>",
+		      .help = "Load XDP program in <xdp_mode>; default native"),
+	DEFINE_OPTION("devs", OPT_IFNAME_MULTI, struct load_opts, ifaces,
+		      .positional = true,
+		      .metavar = "<ifname...>",
+		      .min_num = 1,
+		      .max_num = MAX_IFACE_NUM,
+		      .required = 1,
+		      .help = "Redirect from and to devices <ifname...>"),
+	END_OPTIONS
+};
+
+static int do_load(const void *cfg, __unused const char *pin_root_path)
+{
+	DECLARE_LIBBPF_OPTS(xdp_program_opts, opts);
+	struct xdp_program *xdp_prog = NULL;
+	const struct load_opts *opt = cfg;
+	struct bpf_program *prog = NULL;
+	struct xdp_forward *skel;
+	int ret = EXIT_FAILURE;
+	struct iface *iface;
+
+	switch (opt->fwd_mode) {
+	case FWD_FIB_FULL:
+		opts.prog_name = "xdp_fwd_fib_full";
+		break;
+	case FWD_FIB_DIRECT:
+		opts.prog_name = "xdp_fwd_fib_direct";
+		break;
+	default:
+		goto end;
+	}
+
+	skel = xdp_forward__open();
+	if (!skel) {
+		pr_warn("Failed to load skeleton: %s\n", strerror(errno));
+		goto end;
+	}
+
+	/* Make sure we only load the one XDP program we are interested in */
+	while ((prog = bpf_object__next_program(skel->obj, prog)) != NULL)
+		if (bpf_program__type(prog) == BPF_PROG_TYPE_XDP &&
+		    bpf_program__expected_attach_type(prog) == BPF_XDP)
+			bpf_program__set_autoload(prog, false);
+
+	opts.obj = skel->obj;
+	xdp_prog = xdp_program__create(&opts);
+	if (!xdp_prog) {
+		ret = -errno;
+		pr_warn("Couldn't open XDP program: %s\n",
+			strerror(-ret));
+		goto end_destroy;
+	}
+
+	/* We always set the frags support bit: nothing the program does is
+	 * incompatible with multibuf, and it's perfectly fine to load a program
+	 * with frags support on an interface with a small MTU. We don't risk
+	 * setting any flags the kernel will balk at, either, since libxdp will
+	 * do the feature probing for us and skip the flag if the kernel doesn't
+	 * support it.
+	 *
+	 * The function below returns EOPNOTSUPP it libbpf is too old to support
+	 * setting the flags, but we just ignore that, since in such a case the
+	 * best we can do is just attempt to run without the frags support.
+	 */
+	xdp_program__set_xdp_frags_support(xdp_prog, true);
+
+	for (iface = opt->ifaces; iface; iface = iface->next) {
+		if (find_prog(iface, false) != -ENOENT) {
+			pr_warn("Already attached to %s, not reattaching\n",
+				iface->ifname);
+			continue;
+		}
+
+		ret = xdp_program__attach(xdp_prog, iface->ifindex, opt->xdp_mode, 0);
+		if (ret) {
+			pr_warn("Failed to attach XDP program to iface %s: %s\n",
+				iface->ifname, strerror(-ret));
+			goto end_detach;
+		}
+
+		ret = bpf_map_update_elem(bpf_map__fd(skel->maps.xdp_tx_ports),
+					  &iface->ifindex, &iface->ifindex, 0);
+		if (ret) {
+			pr_warn("Failed to update devmap value: %s\n",
+				strerror(errno));
+			goto end_detach;
+		}
+		pr_info("Loaded on interface %s\n", iface->ifname);
+	}
+
+end_destroy:
+	xdp_forward__destroy(skel);
+end:
+	return ret;
+
+end_detach:
+	for (iface = opt->ifaces; iface; iface = iface->next)
+		xdp_program__detach(xdp_prog, iface->ifindex, opt->xdp_mode, 0);
+	goto end_destroy;
+}
+
+struct unload_opts {
+	struct iface *ifaces;
+} defaults_unload = {};
+
+struct prog_option unload_options[] = {
+	DEFINE_OPTION("devs", OPT_IFNAME_MULTI, struct unload_opts, ifaces,
+		      .positional = true,
+		      .metavar = "<ifname...>",
+		      .min_num = 1,
+		      .max_num = MAX_IFACE_NUM,
+		      .help = "Redirect from and to devices <ifname...>"),
+	END_OPTIONS
+};
+
+
+static int do_unload(const void *cfg, __unused const char *pin_root_path)
+{
+	const struct unload_opts *opt = cfg;
+	int ret = EXIT_SUCCESS;
+	struct iface *iface;
+
+	for (iface = opt->ifaces; iface; iface = iface->next) {
+		if (find_prog(iface, true)) {
+			pr_warn("Couldn't find program on interface %s\n",
+				iface->ifname);
+			ret = EXIT_FAILURE;
+		}
+		pr_info("Unloaded from interface %s\n", iface->ifname);
+	}
+
+	return ret;
+}
+
+static const struct prog_command cmds[] = {
+	DEFINE_COMMAND(load, "Load XDP forwarding plane"),
+	DEFINE_COMMAND(unload, "Unload XDP forwarding plane"),
+	{ .name = "help", .func = do_help, .no_cfg = true },
+	END_COMMANDS
+};
+
+union all_opts {
+	struct load_opts load;
+	struct unload_opts unload;
+};
+
+int main(int argc, char **argv)
+{
+	if (argc > 1)
+		return dispatch_commands(argv[1], argc - 1, argv + 1, cmds,
+					 sizeof(union all_opts), PROG_NAME, false);
+
+	return do_help(NULL, NULL);
+}

--- a/xdp-forward/xdp-forward.c
+++ b/xdp-forward/xdp-forward.c
@@ -35,11 +35,13 @@ struct enum_val xdp_modes[] = { { "native", XDP_MODE_NATIVE },
 
 enum fwd_mode {
 	FWD_FIB_DIRECT,
-	FWD_FIB_FULL
+	FWD_FIB_FULL,
+	FWD_FLOWTABLE,
 };
 
 struct enum_val fwd_modes[] = { { "fib-direct", FWD_FIB_DIRECT },
 				{ "fib-full", FWD_FIB_FULL },
+				{ "flowtable", FWD_FLOWTABLE },
 				{ NULL, 0 } };
 
 static int find_prog(struct iface *iface, bool detach)
@@ -61,7 +63,8 @@ static int find_prog(struct iface *iface, bool detach)
 	while ((prog = xdp_multiprog__next_prog(prog, mp))) {
 	check:
 		if (!strcmp(xdp_program__name(prog), "xdp_fwd_fib_full") ||
-		    !strcmp(xdp_program__name(prog), "xdp_fwd_fib_direct")) {
+		    !strcmp(xdp_program__name(prog), "xdp_fwd_fib_direct") ||
+		    !strcmp(xdp_program__name(prog), "xdp_fwd_flowtable")) {
 			mode = xdp_multiprog__attach_mode(mp);
 			ret = 0;
 			if (detach) {
@@ -123,6 +126,9 @@ static int do_load(const void *cfg, __unused const char *pin_root_path)
 		break;
 	case FWD_FIB_DIRECT:
 		opts.prog_name = "xdp_fwd_fib_direct";
+		break;
+	case FWD_FLOWTABLE:
+		opts.prog_name = "xdp_fwd_flowtable";
 		break;
 	default:
 		goto end;

--- a/xdp-forward/xdp_forward.bpf.c
+++ b/xdp-forward/xdp_forward.bpf.c
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Original xdp_fwd sample Copyright (c) 2017-18 David Ahern <dsahern@gmail.com>
+ */
+
+#include <bpf/vmlinux.h>
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <xdp/parsing_helpers.h>
+
+#define AF_INET	2
+#define AF_INET6	10
+
+#define IPV6_FLOWINFO_MASK              bpf_htons(0x0FFFFFFF)
+
+struct {
+	__uint(type, BPF_MAP_TYPE_DEVMAP);
+	__uint(key_size, sizeof(int));
+	__uint(value_size, sizeof(int));
+	__uint(max_entries, 64);
+} xdp_tx_ports SEC(".maps");
+
+/* from include/net/ip.h */
+static __always_inline int ip_decrease_ttl(struct iphdr *iph)
+{
+	__u32 check = (__u32)iph->check;
+
+	check += (__u32)bpf_htons(0x0100);
+	iph->check = (__sum16)(check + (check >= 0xFFFF));
+	return --iph->ttl;
+}
+
+static __always_inline int xdp_fwd_flags(struct xdp_md *ctx, __u32 flags)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	struct bpf_fib_lookup fib_params;
+	struct ethhdr *eth = data;
+	struct ipv6hdr *ip6h;
+	struct iphdr *iph;
+	__u16 h_proto;
+	__u64 nh_off;
+	int rc;
+
+	nh_off = sizeof(*eth);
+	if (data + nh_off > data_end)
+		return XDP_DROP;
+
+	__builtin_memset(&fib_params, 0, sizeof(fib_params));
+
+	h_proto = eth->h_proto;
+	if (h_proto == bpf_htons(ETH_P_IP)) {
+		iph = data + nh_off;
+
+		if (iph + 1 > data_end)
+			return XDP_DROP;
+
+		if (iph->ttl <= 1)
+			return XDP_PASS;
+
+		fib_params.family	= AF_INET;
+		fib_params.tos		= iph->tos;
+		fib_params.l4_protocol	= iph->protocol;
+		fib_params.sport	= 0;
+		fib_params.dport	= 0;
+		fib_params.tot_len	= bpf_ntohs(iph->tot_len);
+		fib_params.ipv4_src	= iph->saddr;
+		fib_params.ipv4_dst	= iph->daddr;
+	} else if (h_proto == bpf_htons(ETH_P_IPV6)) {
+		struct in6_addr *src = (struct in6_addr *) fib_params.ipv6_src;
+		struct in6_addr *dst = (struct in6_addr *) fib_params.ipv6_dst;
+
+		ip6h = data + nh_off;
+		if (ip6h + 1 > data_end)
+			return XDP_DROP;
+
+		if (ip6h->hop_limit <= 1)
+			return XDP_PASS;
+
+		fib_params.family	= AF_INET6;
+		fib_params.flowinfo	= *(__be32 *)ip6h & IPV6_FLOWINFO_MASK;
+		fib_params.l4_protocol	= ip6h->nexthdr;
+		fib_params.sport	= 0;
+		fib_params.dport	= 0;
+		fib_params.tot_len	= bpf_ntohs(ip6h->payload_len);
+		*src			= ip6h->saddr;
+		*dst			= ip6h->daddr;
+	} else {
+		return XDP_PASS;
+	}
+
+	fib_params.ifindex = ctx->ingress_ifindex;
+
+	rc = bpf_fib_lookup(ctx, &fib_params, sizeof(fib_params), flags);
+	/*
+	 * Some rc (return codes) from bpf_fib_lookup() are important,
+	 * to understand how this XDP-prog interacts with network stack.
+	 *
+	 * BPF_FIB_LKUP_RET_NO_NEIGH:
+	 *  Even if route lookup was a success, then the MAC-addresses are also
+	 *  needed.  This is obtained from arp/neighbour table, but if table is
+	 *  (still) empty then BPF_FIB_LKUP_RET_NO_NEIGH is returned.  To avoid
+	 *  doing ARP lookup directly from XDP, then send packet to normal
+	 *  network stack via XDP_PASS and expect it will do ARP resolution.
+	 *
+	 * BPF_FIB_LKUP_RET_FWD_DISABLED:
+	 *  The bpf_fib_lookup respect sysctl net.ipv{4,6}.conf.all.forwarding
+	 *  setting, and will return BPF_FIB_LKUP_RET_FWD_DISABLED if not
+	 *  enabled this on ingress device.
+	 */
+	if (rc == BPF_FIB_LKUP_RET_SUCCESS) {
+		/* Verify egress index has been configured as TX-port.
+		 * (Note: User can still have inserted an egress ifindex that
+		 * doesn't support XDP xmit, which will result in packet drops).
+		 *
+		 * Note: lookup in devmap supported since 0cdbb4b09a0.
+		 * If not supported will fail with:
+		 *  cannot pass map_type 14 into func bpf_map_lookup_elem#1:
+		 */
+		if (!bpf_map_lookup_elem(&xdp_tx_ports, &fib_params.ifindex))
+			return XDP_PASS;
+
+		if (h_proto == bpf_htons(ETH_P_IP))
+			ip_decrease_ttl(iph);
+		else if (h_proto == bpf_htons(ETH_P_IPV6))
+			ip6h->hop_limit--;
+
+		__builtin_memcpy(eth->h_dest, fib_params.dmac, ETH_ALEN);
+		__builtin_memcpy(eth->h_source, fib_params.smac, ETH_ALEN);
+		return bpf_redirect_map(&xdp_tx_ports, fib_params.ifindex, 0);
+	}
+
+	return XDP_PASS;
+}
+
+SEC("xdp")
+int xdp_fwd_fib_full(struct xdp_md *ctx)
+{
+	return xdp_fwd_flags(ctx, 0);
+}
+
+SEC("xdp")
+int xdp_fwd_fib_direct(struct xdp_md *ctx)
+{
+	return xdp_fwd_flags(ctx, BPF_FIB_LOOKUP_DIRECT);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/xdp-forward/xdp_forward.bpf.c
+++ b/xdp-forward/xdp_forward.bpf.c
@@ -4,13 +4,27 @@
 
 #include <bpf/vmlinux.h>
 #include <linux/bpf.h>
-#include <bpf/bpf_helpers.h>
-#include <xdp/parsing_helpers.h>
+#include <linux/netfilter.h>
+#include <bpf/bpf_core_read.h>
 
-#define AF_INET	2
-#define AF_INET6	10
+#define AF_INET				2
+#define AF_INET6			10
 
 #define IPV6_FLOWINFO_MASK              bpf_htons(0x0FFFFFFF)
+
+#define IP_MF				0x2000	/* "More Fragments" */
+#define IP_OFFSET			0x1fff	/* "Fragment Offset" */
+#define CSUM_MANGLED_0			((__sum16)0xffff)
+
+#define BIT(x)				(1 << (x))
+
+struct bpf_flowtable_opts {
+	__s32 error;
+};
+
+struct flow_offload_tuple_rhash *
+bpf_xdp_flow_lookup(struct xdp_md *, struct bpf_fib_lookup *,
+		    struct bpf_flowtable_opts *, __u32) __ksym;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_DEVMAP);
@@ -142,6 +156,567 @@ SEC("xdp")
 int xdp_fwd_fib_direct(struct xdp_md *ctx)
 {
 	return xdp_fwd_flags(ctx, BPF_FIB_LOOKUP_DIRECT);
+}
+
+static __always_inline __u32 csum_add(__u32 csum, __u32 addend)
+{
+	__u32 res = csum + addend;
+
+	return res + (res < addend);
+}
+
+static __always_inline __u16 csum_fold(__u32 csum)
+{
+	csum = (csum & 0xffff) + (csum >> 16);
+	csum = (csum & 0xffff) + (csum >> 16);
+	return ~csum;
+}
+
+static __always_inline __u16 csum_replace4(__u32 csum, __u32 from, __u32 to)
+{
+	__u32 tmp = csum_add(~csum, ~from);
+
+	return csum_fold(csum_add(tmp, to));
+}
+
+static __always_inline __u16 csum_replace16(__u32 csum, __u32 *from, __u32 *to)
+{
+	__u32 diff[] = {
+		~from[0], ~from[1], ~from[2], ~from[3],
+		to[0], to[1], to[2], to[3],
+	};
+
+	csum = bpf_csum_diff(0, 0, diff, sizeof(diff), ~csum);
+	return csum_fold(csum);
+}
+
+static __always_inline int
+xdp_flowtable_check_tcp_state(void *ports, void *data_end, __u8 proto)
+{
+	if (proto == IPPROTO_TCP) {
+		struct tcphdr *tcph = ports;
+
+		if (tcph + 1 > data_end)
+			return -1;
+
+		if (tcph->fin || tcph->rst)
+			return -1;
+	}
+
+	return 0;
+}
+
+static __always_inline void
+xdp_flowtable_update_port_csum(struct flow_ports *ports, void *data_end,
+			       __u8 proto, __be16 port, __be16 nat_port)
+{
+	switch (proto) {
+	case IPPROTO_TCP: {
+		struct tcphdr *tcph = (struct tcphdr *)ports;
+
+		if (tcph + 1 > data_end)
+			break;
+
+		tcph->check = csum_replace4((__u32)tcph->check, (__u32)port,
+					    (__u32)nat_port);
+		break;
+	}
+	case IPPROTO_UDP: {
+		struct udphdr *udph = (struct udphdr *)ports;
+
+		if (udph + 1 > data_end)
+			break;
+
+		if (!udph->check)
+			break;
+
+		udph->check = csum_replace4((__u32)udph->check, (__u32)port,
+					    (__u32)nat_port);
+		if (!udph->check)
+			udph->check = CSUM_MANGLED_0;
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static __always_inline void
+xdp_flowtable_snat_port(const struct flow_offload *flow,
+			struct flow_ports *ports, void *data_end,
+			__u8 proto, enum flow_offload_tuple_dir dir)
+{
+	__be16 port, nat_port;
+
+	if (ports + 1 > data_end)
+		return;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		port = ports->source;
+		/* For original direction (FLOW_OFFLOAD_DIR_ORIGINAL):
+		 * - tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_port contains
+		 *   the source port used for the traffic transmitted by the
+		 *   host.
+		 * - tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_port contains
+		 *   the destination port used for the traffic transmitted by
+		 *   the host.
+		 */
+		bpf_core_read(&nat_port, bpf_core_type_size(nat_port),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_port);
+		ports->source = nat_port;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		/* For reply direction (FLOW_OFFLOAD_DIR_REPLY):
+		 * - tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_port
+		 *   contains source port used for the traffic received by the
+		 *   host.
+		 * - tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.src_port
+		 *   contains the destination port used for the traffic
+		 *   received by the host.
+		 */
+		port = ports->dest;
+		bpf_core_read(&nat_port, bpf_core_type_size(nat_port),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.src_port);
+		ports->dest = nat_port;
+		break;
+	default:
+		return;
+	}
+
+	xdp_flowtable_update_port_csum(ports, data_end, proto, port, nat_port);
+}
+
+static __always_inline void
+xdp_flowtable_dnat_port(const struct flow_offload *flow,
+			struct flow_ports *ports, void *data_end, __u8 proto,
+			enum flow_offload_tuple_dir dir)
+{
+	__be16 port, nat_port;
+
+	if (ports + 1 > data_end)
+		return;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		/* For original direction (FLOW_OFFLOAD_DIR_ORIGINAL):
+		 * - tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_port contains
+		 *   the source port used for the traffic transmitted by the
+		 *   host.
+		 * - tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_port contains
+		 *   the destination port used for the traffic transmitted by
+		 *   the host.
+		 */
+		port = ports->dest;
+		bpf_core_read(&nat_port, bpf_core_type_size(nat_port),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_port);
+		ports->dest = nat_port;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		/* For reply direction (FLOW_OFFLOAD_DIR_REPLY):
+		 * - tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_port
+		 *   contains the source port used for the traffic received by
+		 *   the host.
+		 * - tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.src_port
+		 *   contains destination port used for the traffic received by
+		 *   the host.
+		 */
+		port = ports->source;
+		bpf_core_read(&nat_port, bpf_core_type_size(nat_port),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_port);
+		ports->source = nat_port;
+		break;
+	default:
+		return;
+	}
+
+	xdp_flowtable_update_port_csum(ports, data_end, proto, port, nat_port);
+}
+
+static __always_inline void
+xdp_flowtable_update_ipv4_csum(struct iphdr *iph, void *data_end,
+			       __be32 addr, __be32 nat_addr)
+{
+	switch (iph->protocol) {
+	case IPPROTO_TCP: {
+		struct tcphdr *tcph = (struct tcphdr *)(iph + 1);
+
+		if (tcph + 1 > data_end)
+			break;
+
+		tcph->check = csum_replace4((__u32)tcph->check, addr,
+					    nat_addr);
+		break;
+	}
+	case IPPROTO_UDP: {
+		struct udphdr *udph = (struct udphdr *)(iph + 1);
+
+		if (udph + 1 > data_end)
+			break;
+
+		if (!udph->check)
+			break;
+
+		udph->check = csum_replace4((__u32)udph->check, addr,
+					    nat_addr);
+		if (!udph->check)
+			udph->check = CSUM_MANGLED_0;
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static __always_inline void
+xdp_flowtable_snat_ip(const struct flow_offload *flow, struct iphdr *iph,
+		      void *data_end, enum flow_offload_tuple_dir dir)
+{
+	__be32 addr, nat_addr;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		addr = iph->saddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_v4.s_addr);
+		iph->saddr = nat_addr;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		addr = iph->daddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.src_v4.s_addr);
+		iph->daddr = nat_addr;
+		break;
+	default:
+		return;
+	}
+	iph->check = csum_replace4((__u32)iph->check, addr, nat_addr);
+
+	xdp_flowtable_update_ipv4_csum(iph, data_end, addr, nat_addr);
+}
+
+static __always_inline void
+xdp_flowtable_get_dnat_ip(__be32 *addr, const struct flow_offload *flow,
+			  enum flow_offload_tuple_dir dir)
+{
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		bpf_core_read(addr, sizeof(*addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_v4.s_addr);
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		bpf_core_read(addr, sizeof(*addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_v4.s_addr);
+		break;
+	}
+}
+
+static __always_inline void
+xdp_flowtable_dnat_ip(const struct flow_offload *flow, struct iphdr *iph,
+		      void *data_end, enum flow_offload_tuple_dir dir)
+{
+	__be32 addr, nat_addr;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		addr = iph->daddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_v4.s_addr);
+		iph->daddr = nat_addr;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		addr = iph->saddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_v4.s_addr);
+		iph->saddr = nat_addr;
+		break;
+	default:
+		return;
+	}
+	iph->check = csum_replace4((__u32)iph->check, addr, nat_addr);
+
+	xdp_flowtable_update_ipv4_csum(iph, data_end, addr, nat_addr);
+}
+
+static __always_inline void
+xdp_flowtable_update_ipv6_csum(struct ipv6hdr *ip6h, void *data_end,
+			       struct in6_addr *addr,
+			       struct in6_addr *nat_addr)
+{
+	switch (ip6h->nexthdr) {
+	case IPPROTO_TCP: {
+		struct tcphdr *tcph = (struct tcphdr *)(ip6h + 1);
+
+		if (tcph + 1 > data_end)
+			break;
+
+		tcph->check = csum_replace16((__u32)tcph->check,
+					     addr->in6_u.u6_addr32,
+					     nat_addr->in6_u.u6_addr32);
+		break;
+	}
+	case IPPROTO_UDP: {
+		struct udphdr *udph = (struct udphdr *)(ip6h + 1);
+
+		if (udph + 1 > data_end)
+			break;
+
+		if (!udph->check)
+			break;
+
+		udph->check = csum_replace16((__u32)udph->check,
+					     addr->in6_u.u6_addr32,
+					     nat_addr->in6_u.u6_addr32);
+		if (!udph->check)
+			udph->check = CSUM_MANGLED_0;
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static __always_inline void
+xdp_flowtable_snat_ipv6(const struct flow_offload *flow, struct ipv6hdr *ip6h,
+			void *data_end, enum flow_offload_tuple_dir dir)
+{
+	struct in6_addr addr, nat_addr;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		addr = ip6h->saddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.dst_v6);
+		ip6h->saddr = nat_addr;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		addr = ip6h->daddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.src_v6);
+		ip6h->daddr = nat_addr;
+		break;
+	default:
+		return;
+	}
+
+	xdp_flowtable_update_ipv6_csum(ip6h, data_end, &addr, &nat_addr);
+}
+
+static __always_inline void
+xdp_flowtable_get_dnat_ipv6(struct in6_addr *addr,
+			    const struct flow_offload *flow,
+			    enum flow_offload_tuple_dir dir)
+{
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		bpf_core_read(addr, sizeof(*addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_v6);
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		bpf_core_read(addr, sizeof(*addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_v6);
+		break;
+	}
+}
+
+static __always_inline void
+xdp_flowtable_dnat_ipv6(const struct flow_offload *flow, struct ipv6hdr *ip6h,
+			void *data_end, enum flow_offload_tuple_dir dir)
+{
+	struct in6_addr addr, nat_addr;
+
+	switch (dir) {
+	case FLOW_OFFLOAD_DIR_ORIGINAL:
+		addr = ip6h->daddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple.src_v6);
+		ip6h->daddr = nat_addr;
+		break;
+	case FLOW_OFFLOAD_DIR_REPLY:
+		addr = ip6h->saddr;
+		bpf_core_read(&nat_addr, bpf_core_type_size(nat_addr),
+			      &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple.dst_v6);
+		ip6h->saddr = nat_addr;
+		break;
+	default:
+		return;
+	}
+
+	xdp_flowtable_update_ipv6_csum(ip6h, data_end, &addr, &nat_addr);
+}
+
+static __always_inline void
+xdp_flowtable_forward_ip(const struct flow_offload *flow, void *data,
+			 void *data_end, struct flow_ports *ports,
+			 enum flow_offload_tuple_dir dir,
+			 unsigned long flags)
+{
+	struct iphdr *iph = data + sizeof(struct ethhdr);
+
+	if (iph + 1 > data_end)
+		return;
+
+	if (flags & BIT(NF_FLOW_SNAT)) {
+		xdp_flowtable_snat_port(flow, ports, data_end, iph->protocol,
+					dir);
+		xdp_flowtable_snat_ip(flow, iph, data_end, dir);
+	}
+	if (flags & BIT(NF_FLOW_DNAT)) {
+		xdp_flowtable_dnat_port(flow, ports, data_end, iph->protocol,
+					dir);
+		xdp_flowtable_dnat_ip(flow, iph, data_end, dir);
+	}
+
+	ip_decrease_ttl(iph);
+}
+
+static __always_inline void
+xdp_flowtable_forward_ipv6(const struct flow_offload *flow, void *data,
+			   void *data_end, struct flow_ports *ports,
+			   enum flow_offload_tuple_dir dir,
+			   unsigned long flags)
+{
+	struct ipv6hdr *ip6h = data + sizeof(struct ethhdr);
+
+	if (ip6h + 1 > data_end)
+		return;
+
+	if (flags & BIT(NF_FLOW_SNAT)) {
+		xdp_flowtable_snat_port(flow, ports, data_end, ip6h->nexthdr,
+					dir);
+		xdp_flowtable_snat_ipv6(flow, ip6h, data_end, dir);
+	}
+	if (flags & BIT(NF_FLOW_DNAT)) {
+		xdp_flowtable_dnat_port(flow, ports, data_end, ip6h->nexthdr,
+					dir);
+		xdp_flowtable_dnat_ipv6(flow, ip6h, data_end, dir);
+	}
+
+	ip6h->hop_limit--;
+}
+
+SEC("xdp")
+int xdp_fwd_flowtable(struct xdp_md *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	struct flow_offload_tuple_rhash *tuplehash;
+	struct bpf_fib_lookup tuple = {
+		.ifindex = ctx->ingress_ifindex,
+	};
+	void *data = (void *)(long)ctx->data;
+	struct bpf_flowtable_opts opts = {};
+	enum flow_offload_tuple_dir dir;
+	struct ethhdr *eth = data;
+	struct flow_offload *flow;
+	struct flow_ports *ports;
+	unsigned long flags;
+
+	if (eth + 1 > data_end)
+		return XDP_PASS;
+
+	switch (eth->h_proto) {
+	case bpf_htons(ETH_P_IP): {
+		struct iphdr *iph = data + sizeof(*eth);
+
+		ports = (struct flow_ports *)(iph + 1);
+		if (ports + 1 > data_end)
+			return XDP_PASS;
+
+		/* ip fragmented traffic */
+		if (iph->frag_off & bpf_htons(IP_MF | IP_OFFSET))
+			return XDP_PASS;
+
+		/* ip options */
+		if (iph->ihl * 4 != sizeof(*iph))
+			return XDP_PASS;
+
+		if (iph->ttl <= 1)
+			return XDP_PASS;
+
+		if (xdp_flowtable_check_tcp_state(ports, data_end,
+						  iph->protocol) < 0)
+			return XDP_PASS;
+
+		tuple.family		= AF_INET;
+		tuple.tos		= iph->tos;
+		tuple.l4_protocol	= iph->protocol;
+		tuple.tot_len		= bpf_ntohs(iph->tot_len);
+		tuple.ipv4_src		= iph->saddr;
+		tuple.ipv4_dst		= iph->daddr;
+		tuple.sport		= ports->source;
+		tuple.dport		= ports->dest;
+		break;
+	}
+	case bpf_htons(ETH_P_IPV6): {
+		struct in6_addr *src = (struct in6_addr *)tuple.ipv6_src;
+		struct in6_addr *dst = (struct in6_addr *)tuple.ipv6_dst;
+		struct ipv6hdr *ip6h = data + sizeof(*eth);
+
+		ports = (struct flow_ports *)(ip6h + 1);
+		if (ports + 1 > data_end)
+			return XDP_PASS;
+
+		if (ip6h->hop_limit <= 1)
+			return XDP_PASS;
+
+		if (xdp_flowtable_check_tcp_state(ports, data_end,
+						  ip6h->nexthdr) < 0)
+			return XDP_PASS;
+
+		tuple.family		= AF_INET6;
+		tuple.l4_protocol	= ip6h->nexthdr;
+		tuple.tot_len		= bpf_ntohs(ip6h->payload_len);
+		*src			= ip6h->saddr;
+		*dst			= ip6h->daddr;
+		tuple.sport		= ports->source;
+		tuple.dport		= ports->dest;
+		break;
+	}
+	default:
+		return XDP_PASS;
+	}
+
+	tuplehash = bpf_xdp_flow_lookup(ctx, &tuple, &opts, sizeof(opts));
+	if (!tuplehash)
+		return XDP_PASS;
+
+	dir = tuplehash->tuple.dir;
+	if (dir >= FLOW_OFFLOAD_DIR_MAX)
+		return XDP_PASS;
+
+	flow = container_of(tuplehash, struct flow_offload, tuplehash[dir]);
+	if (bpf_core_read(&flags, sizeof(flags), &flow->flags))
+		return XDP_PASS;
+
+	if (tuplehash->tuple.xmit_type != FLOW_OFFLOAD_XMIT_NEIGH)
+		return XDP_PASS;
+
+	/* update the destination address in case of dnatting before
+	 * performing the route lookup
+	 */
+	if (tuple.family == AF_INET6) {
+		struct in6_addr *dst_addr = (struct in6_addr *)&tuple.ipv6_dst;
+
+		xdp_flowtable_get_dnat_ipv6(dst_addr, flow, dir);
+	} else {
+		xdp_flowtable_get_dnat_ip(&tuple.ipv4_dst, flow, dir);
+	}
+
+	if (bpf_fib_lookup(ctx, &tuple, sizeof(tuple), 0) !=
+	    BPF_FIB_LKUP_RET_SUCCESS)
+		return XDP_PASS;
+
+	if (tuple.family == AF_INET6)
+		xdp_flowtable_forward_ipv6(flow, data, data_end, ports, dir,
+					   flags);
+	else
+		xdp_flowtable_forward_ip(flow, data, data_end, ports, dir,
+					 flags);
+
+	__builtin_memcpy(eth->h_dest, tuple.dmac, ETH_ALEN);
+	__builtin_memcpy(eth->h_source, tuple.smac, ETH_ALEN);
+
+	return bpf_redirect(tuple.ifindex, 0);
 }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Introduce xdp-fwd-flowtable sample in order to perform XDP_REDIRECT between net_devices inserted in a netfilter flowtable.