### PR TITLE
libxdp: Expose xdp_program__attach_single()

### DIFF
--- a/headers/xdp/libxdp.h
+++ b/headers/xdp/libxdp.h
@@ -98,6 +98,8 @@ int xdp_program__attach(struct xdp_program *xdp_prog,
 int xdp_program__attach_multi(struct xdp_program **progs, size_t num_progs,
 			      int ifindex, enum xdp_attach_mode mode,
 			      unsigned int flags);
+int xdp_program__attach_single(struct xdp_program *prog, int ifindex,
+                               enum xdp_attach_mode mode);
 int xdp_program__detach(struct xdp_program *xdp_prog,
 			int ifindex, enum xdp_attach_mode mode,
 			unsigned int flags);

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -1681,7 +1681,7 @@ static bool kernel_has_frags_support(void)
 }
 #endif // HAVE_LIBBPF_BPF_PROGRAM__FLAGS
 
-static int xdp_program__attach_single(struct xdp_program *prog, int ifindex,
+int xdp_program__attach_single(struct xdp_program *prog, int ifindex,
 				      enum xdp_attach_mode mode)
 {
 	int err;

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -78,5 +78,6 @@ LIBXDP_1.3.0 {
 } LIBXDP_1.2.0;
 
 LIBXDP_1.4.0 {
+		xdp_program__attach_single;
 		xsk_umem__create_with_fd;
 } LIBXDP_1.3.0;


### PR DESCRIPTION
Hi,
I (and potentially other library users) would like to load a single XDP program while skipping the dispatcher without modifying the environment.

I successfully tested this patch in my environment, but if there's another place that needs changing for exposing this function, please let me know.