### PR TITLE
Set BPF Skeleton name to base name of ebpf file

### DIFF
--- a/lib/common.mk
+++ b/lib/common.mk
@@ -121,7 +121,7 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
 
 $(BPF_SKEL_H): %.skel.h: %.bpf.o
-	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< name ${@:.skel.h=} > $@
+	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< name $(notdir ${@:.skel.h=}) > $@
 
 .PHONY: man
 ifeq ($(EMACS),)


### PR DESCRIPTION
The current build system sets the name of the generated skeleton directly to the file's name minus the `.skel.h` suffix.
Passing names of eBPF targets that contain a directory will result in wrong names e.g. `bpf/xdp_program.bpf.o` will have a skeleton file of the name `bpf/xdp_program.skel.h` and consequently the program name will be `bpf/xdp_program` instead of `xdp_program`. The commit pops out the directory part from the name.