### PR TITLE
xdp-loader/README: netronome cards have HW support

### DIFF
--- a/xdp-loader/README.org
+++ b/xdp-loader/README.org
@@ -56,8 +56,8 @@ to the kernel to pick a mode (which it will do by picking native mode if the
 driver supports it, or generic mode otherwise). Note that using 'unspecified'
 can make it difficult to predict what mode a program will end up being loaded
 in. For this reason, the default is 'native'. Note that hardware with support
-for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
-only devices with support for this in the mainline Linux kernel.
+for the 'hw' mode is rare: Netronome/Corigine cards (using the 'nfp' driver) are
+the only devices with support for this in the mainline Linux kernel.
 
 ** -p, --pin-path <path>
 This specifies a root path under which to pin any maps that define the 'pinning'

--- a/xdp-loader/xdp-loader.8
+++ b/xdp-loader/xdp-loader.8
@@ -61,8 +61,8 @@ to the kernel to pick a mode (which it will do by picking native mode if the
 driver supports it, or generic mode otherwise). Note that using 'unspecified'
 can make it difficult to predict what mode a program will end up being loaded
 in. For this reason, the default is 'native'. Note that hardware with support
-for the 'hw' mode is rare: Solarflare cards (using the 'sfc' driver) are the
-only devices with support for this in the mainline Linux kernel.
+for the 'hw' mode is rare: Netronome/Corigine cards (using the 'nfp' driver) are
+the only devices with support for this in the mainline Linux kernel.
 
 .SS "-p, --pin-path <path>"
 .PP


### PR DESCRIPTION
There appears to have been a mixup in the [original PR] in the list of card with HW support.

Solarflare cards do not have HW support, only Netronome/Corigine cards do.


[original PR]: https://github.com/xdp-project/xdp-tools/pull/243