### PR TITLE
fix compile xdp-forward fail

### DIFF
--- a/xdp-forward/xdp-forward.c
+++ b/xdp-forward/xdp-forward.c
@@ -8,6 +8,7 @@
 #include "params.h"
 #include "util.h"
 #include "logging.h"
+#include "compat.h"
 
 #include "xdp_forward.skel.h"
 


### PR DESCRIPTION
**OS: ubuntu2204.localdomain 5.15.0-91-generic
compile error:**
xdp-forward.c: In function ‘do_load’:
xdp-forward.c:139:24: error: implicit declaration of function ‘bpf_object__next_program’; did you mean ‘bpf_object__unpin_programs’? [-Werror=implicit-function-declaration]
  139 |         while ((prog = bpf_object__next_program(skel->obj, prog)) != NULL)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
      |                        bpf_object__unpin_programs
xdp-forward.c:139:22: error: assignment to ‘struct bpf_program *’ from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion]
  139 |         while ((prog = bpf_object__next_program(skel->obj, prog)) != NULL)
      |                      ^
xdp-forward.c:140:21: error: implicit declaration of function ‘bpf_program__type’; did you mean ‘bpf_program__size’? [-Werror=implicit-function-declaration]
  140 |                 if (bpf_program__type(prog) == BPF_PROG_TYPE_XDP &&
      |                     ^~~~~~~~~~~~~~~~~
      |                     bpf_program__size
xdp-forward.c:141:21: error: implicit declaration of function ‘bpf_program__expected_attach_type’; did you mean ‘bpf_program__set_expected_attach_type’? [-Werror=implicit-function-declaration]
  141 |                     bpf_program__expected_attach_type(prog) == BPF_XDP)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                     bpf_program__set_expected_attach_type
cc1: all warnings being treated as errors
make[1]: *** [../lib/common.mk:107: xdp-forward] Error 1
make: *** [Makefile:40: xdp-forward] Error 2