### PR TITLE
xdp-forward: fix typos in test-xdp-forward.sh

### DIFF
--- a/xdp-forward/tests/test-xdp-forward.sh
+++ b/xdp-forward/tests/test-xdp-forward.sh
@@ -31,8 +31,8 @@ test_fwd_full()
     for ip in "${ALL_INSIDE_IP4[@]}"; do
         check_run ns_exec ping -c 1 -W 2 $ip
     done
-    for ip in "${ALL_INSIDE_IP4[@]}"; do
-        check_run ns_exec ping -c 1 -W 2 $ip
+    for ip in "${ALL_INSIDE_IP6[@]}"; do
+        check_run ns_exec $PING6 -c 1 -W 2 $ip
     done
     check_run $XDP_FORWARD unload ${NS_NAMES[@]}
 }
@@ -46,8 +46,8 @@ test_fwd_direct()
     for ip in "${ALL_INSIDE_IP4[@]}"; do
         check_run ns_exec ping -c 1 -W 2 $ip
     done
-    for ip in "${ALL_INSIDE_IP4[@]}"; do
-        check_run ns_exec ping -c 1 -W 2 $ip
+    for ip in "${ALL_INSIDE_IP6[@]}"; do
+        check_run ns_exec $PING6 -c 1 -W 2 $ip
     done
     check_run $XDP_FORWARD unload ${NS_NAMES[@]}
 }


### PR DESCRIPTION
Test IPv6 in test_fwd_full and test_fwd_direct and not IPv4 twice.