### PR TITLE
libxdp: Add tx_metadata_len/xsk_umem__create_opts() to support AF_XDP Tx metadata

### DIFF
--- a/headers/linux/if_xdp.h
+++ b/headers/linux/if_xdp.h
@@ -70,6 +70,7 @@ struct xdp_umem_reg {
 	__u32 chunk_size;
 	__u32 headroom;
 	__u32 flags;
+	__u32 tx_metadata_len;
 };
 
 struct xdp_statistics {

--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -194,6 +194,7 @@ int xsk_socket__fd(const struct xsk_socket *xsk);
 #define XSK_UMEM__DEFAULT_FRAME_SIZE     (1 << XSK_UMEM__DEFAULT_FRAME_SHIFT)
 #define XSK_UMEM__DEFAULT_FRAME_HEADROOM 0
 #define XSK_UMEM__DEFAULT_FLAGS 0
+#define XSK_UMEM__DEFAULT_TX_METADATA_LEN 0
 
 struct xsk_umem_config {
 	__u32 fill_size;
@@ -202,6 +203,31 @@ struct xsk_umem_config {
 	__u32 frame_headroom;
 	__u32 flags;
 };
+
+/* The following fields are optional:
+ * 
+ * @fd, @size, @fill_size, @comp_size, @frame_size, @frame_headroom,
+ * @flags, @tx_metadata_len
+ *  If @fd is unset, a new sockfd will be created.
+ *  If @size is unset, @umem_area must be page-aligned.
+ *  If the remaining fields are unset, they will be set to 
+ *  default value (see `xsk_set_umem_config()`).
+ * 
+ * Except for the fields mentioned above, none field can be set.
+ */
+struct xsk_umem_opts {
+	size_t sz;
+	int fd;
+	__u64 size;
+	__u32 fill_size;
+	__u32 comp_size;
+	__u32 frame_size;
+	__u32 frame_headroom;
+	__u32 flags;
+	__u32 tx_metadata_len;
+	size_t :0;
+};
+#define xsk_umem_opts__last_field tx_metadata_len
 
 int xsk_setup_xdp_prog(int ifindex, int *xsks_map_fd);
 int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
@@ -234,6 +260,12 @@ int xsk_umem__create_with_fd(struct xsk_umem **umem,
 			     struct xsk_ring_prod *fill,
 			     struct xsk_ring_cons *comp,
 			     const struct xsk_umem_config *config);
+/* Newer version to create umem by opts, recommended to use. */
+struct xsk_umem *xsk_umem__create_opts(void *umem_area,
+				       struct xsk_ring_prod *fill,
+				       struct xsk_ring_cons *comp,
+				       struct xsk_umem_opts *opts);
+
 int xsk_socket__create(struct xsk_socket **xsk,
 		       const char *ifname, __u32 queue_id,
 		       struct xsk_umem *umem,

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -80,3 +80,7 @@ LIBXDP_1.3.0 {
 LIBXDP_1.4.0 {
 		xsk_umem__create_with_fd;
 } LIBXDP_1.3.0;
+
+LIBXDP_1.5.0 {
+		xsk_umem__create_opts;
+} LIBXDP_1.4.0;


### PR DESCRIPTION
Currently, we cannot assign metadata length in param `config` when calling `xsk_umem__create()`. This PR adds the support to assign `tx_metadata_len` when creating umem.
Also, adding `xsk_umem__create_opts()` to provide a new way to create umem by opts macro.