### PR TITLE
util/xdp_sample: remove <sys/sysinfo.h> for musl compatibility

### DIFF
--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <bpf/libbpf.h>
-#include <sys/sysinfo.h>
 #include <sys/timerfd.h>
 #include <sys/utsname.h>
 #include <linux/limits.h>


### PR DESCRIPTION
In the musl libc environment, `<sys/sysinfo.h>` also defines the `sysinfo` struct, causing a redefinition conflict:

```cpp
toolchain-x86_64_gcc-14.2.0_musl/include/linux/kernel.h:5,
                 from ../../headers/linux/hashtable.h:15,
                 from xdp_sample.c:33:
toolchain-x86_64_gcc-14.2.0_musl/include/linux/sysinfo.h:8:8: error: redefinition of 'struct sysinfo'
    8 | struct sysinfo {
      |        ^~~~~~~
In file included from xdp_sample.c:24:
toolchain-x86_64_gcc-14.2.0_musl/include/sys/sysinfo.h:10:8: note: originally defined here
   10 | struct sysinfo {
      |        ^~~~~~~
```
<br>

This commit removes the `<sys/sysinfo.h>` include.
It seems that none of its symbols are used in the `xdp_sample` code anyway.