### PR TITLE
xdp-bench: Enable the xdp_frags flag for dummy programs

### DIFF
--- a/xdp-bench/xdp_redirect_basic.c
+++ b/xdp-bench/xdp_redirect_basic.c
@@ -120,6 +120,8 @@ int do_redirect_basic(const void *cfg, __unused const char *pin_root_path)
 		goto end_detach;
 	}
 
+	xdp_program__set_xdp_frags_support(dummy_prog, true);
+
 	ret = xdp_program__attach(dummy_prog, opt->iface_out.ifindex, opt->mode, 0);
 	if (ret < 0) {
 		pr_warn("Failed to attach dummy program: %s\n", strerror(-ret));

--- a/xdp-bench/xdp_redirect_devmap.c
+++ b/xdp-bench/xdp_redirect_devmap.c
@@ -174,6 +174,8 @@ restart:
 		goto end_detach;
 	}
 
+	xdp_program__set_xdp_frags_support(dummy_prog, true);
+
 	ret = xdp_program__attach(dummy_prog, opt->iface_out.ifindex, opt->mode, 0);
 	if (ret < 0) {
 		pr_warn("Failed to attach dummy program: %s\n", strerror(-ret));


### PR DESCRIPTION
Before this commit, the redirect dummy programs would fail to load on interfaces with non-linear MTU.