### PR TITLE
xdp-bench: Add support for the redirect action with --load-mode load-bytes

### DIFF
--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -78,13 +78,12 @@ flushing it back out if writing).
 The default for this option is =no-touch=.
 
 ** -l, --load-mode <MODE>
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with =-p parse-ip=). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 #+begin_src sh
  dpa		- Use traditional Direct Packet Access from the XDP program
- load-bytes		- Use the xdp_load_bytes() helper function to load the data
+ load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 #+end_src
 
 This can be used to benchmark the various packet access modes supported by the
@@ -154,13 +153,12 @@ following actions are available:
 The default for this option is =no-touch=.
 
 ** -l, --load-mode <MODE>
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with =-p parse-ip=). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 #+begin_src sh
  dpa		- Use traditional Direct Packet Access from the XDP program
- load-bytes		- Use the xdp_load_bytes() helper function to load the data
+ load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 #+end_src
 
 This can be used to benchmark the various packet access modes supported by the
@@ -234,13 +232,12 @@ allows this function to be turned off.
 The default for this option is =swap-macs=.
 
 ** -l, --load-mode <MODE>
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with =-p parse-ip=). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 #+begin_src sh
  dpa		- Use traditional Direct Packet Access from the XDP program
- load-bytes		- Use the xdp_load_bytes() helper function to load the data
+ load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 #+end_src
 
 This can be used to benchmark the various packet access modes supported by the

--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -290,6 +290,20 @@ be redirect to the output interface =<ifname_out>=.
 
 The supported options are:
 
+** -l, --load-mode <MODE>
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
+
+#+begin_src sh
+ dpa		- Use traditional Direct Packet Access from the XDP program
+ load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
+#+end_src
+
+This can be used to benchmark the various packet access modes supported by the
+kernel.
+
+The default for this option is =dpa=.
+
 ** -i, --interval <SECONDS>
 Set the polling interval for collecting all statistics and displaying them to
 the output. The unit of interval is in seconds.

--- a/xdp-bench/tests/test-xdp-bench.sh
+++ b/xdp-bench/tests/test-xdp-bench.sh
@@ -35,10 +35,20 @@ test_xdp_load_bytes()
     export XDP_SAMPLE_IMMEDIATE_EXIT=1
 
     for action in drop pass tx; do
-        check_run $XDP_BENCH $action $NS -p parse-ip -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -l load-bytes -vv
         check_run $XDP_BENCH $action $NS -p read-data -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -p parse-ip -l load-bytes -vv
         check_run $XDP_BENCH $action $NS -p swap-macs -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -m skb -l load-bytes -vv
+        check_run $XDP_BENCH $action $NS -e -l load-bytes -vv
     done
+
+    check_run ip link add dev btest0 type veth peer name btest1
+    check_run $XDP_BENCH redirect btest0 btest1 -l load-bytes -vv
+    check_run $XDP_BENCH redirect btest0 btest1 -s -l load-bytes -vv
+    check_run $XDP_BENCH redirect btest0 btest1 -m skb -l load-bytes -vv
+    check_run $XDP_BENCH redirect btest0 btest1 -e -l load-bytes -vv
+    ip link del dev btest0
 }
 
 test_rxq_stats()

--- a/xdp-bench/xdp-bench.8
+++ b/xdp-bench/xdp-bench.8
@@ -92,14 +92,13 @@ The default for this option is \fIno\-touch\fP.
 
 .SS "-l, --load-mode <MODE>"
 .PP
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with \fI\-p parse\-ip\fP). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 .RS
 .nf
-\fCdpa		- Use traditional Direct Packet Access from the XDP program
-load-bytes		- Use the xdp_load_bytes() helper function to load the data
+\fCdpa			- Use traditional Direct Packet Access from the XDP program
+load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 \fP
 .fi
 .RE
@@ -191,14 +190,13 @@ The default for this option is \fIno\-touch\fP.
 
 .SS "-l, --load-mode <MODE>"
 .PP
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with \fI\-p parse\-ip\fP). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 .RS
 .nf
-\fCdpa		- Use traditional Direct Packet Access from the XDP program
-load-bytes		- Use the xdp_load_bytes() helper function to load the data
+\fCdpa			- Use traditional Direct Packet Access from the XDP program
+load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 \fP
 .fi
 .RE
@@ -295,14 +293,13 @@ The default for this option is \fIswap\-macs\fP.
 
 .SS "-l, --load-mode <MODE>"
 .PP
-Specify which mechanism xdp-bench should use to load the packet data when
-parsing the IP header (used with \fI\-p parse\-ip\fP). The following modes are
-available:
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
 
 .RS
 .nf
-\fCdpa		- Use traditional Direct Packet Access from the XDP program
-load-bytes		- Use the xdp_load_bytes() helper function to load the data
+\fCdpa			- Use traditional Direct Packet Access from the XDP program
+load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
 \fP
 .fi
 .RE

--- a/xdp-bench/xdp-bench.8
+++ b/xdp-bench/xdp-bench.8
@@ -368,6 +368,26 @@ be redirect to the output interface \fI<ifname_out>\fP.
 .PP
 The supported options are:
 
+.SS "-l, --load-mode <MODE>"
+.PP
+Specify which mechanism xdp-bench should use to load (and store) the packet data.
+The following modes are available:
+
+.RS
+.nf
+\fCdpa			- Use traditional Direct Packet Access from the XDP program
+load-bytes	- Use the xdp_load_bytes() and xdp_store_bytes() helper functions
+\fP
+.fi
+.RE
+
+.PP
+This can be used to benchmark the various packet access modes supported by the
+kernel.
+
+.PP
+The default for this option is \fIdpa\fP.
+
 .SS "-i, --interval <SECONDS>"
 .PP
 Set the polling interval for collecting all statistics and displaying them to

--- a/xdp-bench/xdp-bench.c
+++ b/xdp-bench/xdp-bench.c
@@ -107,6 +107,11 @@ struct prog_option basic_options[] = {
 };
 
 struct prog_option redirect_basic_options[] = {
+	DEFINE_OPTION("load-mode", OPT_ENUM, struct redirect_opts, load_mode,
+		      .short_opt = 'l',
+                      .metavar = "<mode>",
+                      .typearg = basic_load_modes,
+		      .help = "How to load (and store) data; default dpa"),
 	DEFINE_OPTION("interval", OPT_U32, struct redirect_opts, interval,
 		      .short_opt = 'i',
 		      .metavar = "<seconds>",

--- a/xdp-bench/xdp-bench.c
+++ b/xdp-bench/xdp-bench.c
@@ -82,7 +82,7 @@ struct prog_option basic_options[] = {
 		      .short_opt = 'l',
                       .metavar = "<mode>",
                       .typearg = basic_load_modes,
-		      .help = "How to load data when parsing IP header (with -p parse-ip; default dpa)"),
+		      .help = "How to load (and store) data; default dpa"),
 	DEFINE_OPTION("rxq-stats", OPT_BOOL, struct basic_opts, rxq_stats,
 		      .short_opt = 'r',
 		      .help = "Collect per-RXQ drop statistics"),

--- a/xdp-bench/xdp-bench.h
+++ b/xdp-bench/xdp-bench.h
@@ -43,6 +43,7 @@ struct redirect_opts {
 	bool extended;
 	__u32 interval;
 	enum xdp_attach_mode mode;
+	enum basic_load_mode load_mode;
 	struct iface iface_in;
 	struct iface iface_out;
 };

--- a/xdp-bench/xdp_redirect_basic.c
+++ b/xdp-bench/xdp_redirect_basic.c
@@ -39,6 +39,7 @@ int do_redirect_basic(const void *cfg, __unused const char *pin_root_path)
 
 	struct xdp_program *xdp_prog = NULL, *dummy_prog = NULL;
 	DECLARE_LIBBPF_OPTS(xdp_program_opts, opts);
+	struct bpf_program *prog = NULL;
 	struct xdp_redirect_basic *skel;
 	char str[2 * IF_NAMESIZE + 1];
 	int ret = EXIT_FAIL_OPTION;
@@ -73,8 +74,14 @@ int do_redirect_basic(const void *cfg, __unused const char *pin_root_path)
 	skel->rodata->to_match[0] = opt->iface_out.ifindex;
 	skel->rodata->ifindex_out = opt->iface_out.ifindex;
 
+	/* Make sure we only load the one XDP program we are interested in */
+	while ((prog = bpf_object__next_program(skel->obj, prog)) != NULL)
+		if (bpf_program__type(prog) == BPF_PROG_TYPE_XDP &&
+		    bpf_program__expected_attach_type(prog) == BPF_XDP)
+			bpf_program__set_autoload(prog, false);
+
 	opts.obj = skel->obj;
-	opts.prog_name = bpf_program__name(skel->progs.xdp_redirect_basic_prog);
+	opts.prog_name = (opt->load_mode == BASIC_LOAD_BYTES) ? "xdp_redirect_load_bytes_prog" : "xdp_redirect_prog";
 	xdp_prog = xdp_program__create(&opts);
 	if (!xdp_prog) {
 		ret = -errno;


### PR DESCRIPTION
This pull request extends the --load-mode flag functionality to xdp_redirect_basic.

This continues the work done in pull request #409,
to ensure support for the xdp-bench basic redirect action when the linear part is empty.