### PR TITLE
libxdp: Doc adaptation for XSk umem opts-creation

### DIFF
--- a/lib/libxdp/README.org
+++ b/lib/libxdp/README.org
@@ -267,10 +267,14 @@ BPF maps which is a must if users want to add their own XDP program.
 
 If there is already a socket created with socket(AF_XDP, SOCK_RAW, 0)
 not bound and not tied to any umem, file descriptor of this socket can
-be used in an xsk_umem__create_with_fd() variant of the umem creation
-function.
+be used in param opts of xsk_umem__create_opts(), which is a recommended
+way of umem creation.
 
 #+begin_src C
+struct xsk_umem *xsk_umem__create_opts(void *umem_area,
+				       struct xsk_ring_prod *fill,
+				       struct xsk_ring_cons *comp,
+				       struct xsk_umem_opts *opts);
 int xsk_umem__create(struct xsk_umem **umem,
 		     void *umem_area, __u64 size,
 		     struct xsk_ring_prod *fill,
@@ -324,8 +328,8 @@ int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
 
 To further reduce required level of privileges, an AF_XDP socket can be created
 beforehand with socket(AF_XDP, SOCK_RAW, 0) and passed to a non-privileged
-process.  This socket can be used in xsk_umem__create_with_fd() and later
-in xsk_socket__create() with created umem.  xsk_socket__create_shared() would
+process.  This socket can be used in xsk_umem__create_opts() and later in
+xsk_socket__create() with created umem.  xsk_socket__create_shared() would
 still require privileges for AF_XDP socket creation.
 
 ** Data path

--- a/lib/libxdp/libxdp.3
+++ b/lib/libxdp/libxdp.3
@@ -301,12 +301,16 @@ BPF maps which is a must if users want to add their own XDP program.
 .PP
 If there is already a socket created with socket(AF_XDP, SOCK_RAW, 0)
 not bound and not tied to any umem, file descriptor of this socket can
-be used in an xsk_umem__create_with_fd() variant of the umem creation
-function.
+be used in param opts of xsk_umem__create_opts(), which is a recommended
+way of umem creation.
 
 .RS
 .nf
-\fCint xsk_umem__create(struct xsk_umem **umem,
+\fCstruct xsk_umem *xsk_umem__create_opts(void *umem_area,
+					  struct xsk_ring_prod *fill,
+					  struct xsk_ring_cons *comp,
+					  struct xsk_umem_opts *opts);
+int xsk_umem__create(struct xsk_umem **umem,
                      void *umem_area, __u64 size,
                      struct xsk_ring_prod *fill,
                      struct xsk_ring_cons *comp,
@@ -370,8 +374,8 @@ int xsk_socket__update_xskmap(struct xsk_socket *xsk, int xsks_map_fd);
 .PP
 To further reduce required level of privileges, an AF_XDP socket can be created
 beforehand with socket(AF_XDP, SOCK_RAW, 0) and passed to a non-privileged
-process.  This socket can be used in xsk_umem__create_with_fd() and later
-in xsk_socket__create() with created umem.  xsk_socket__create_shared() would
+process.  This socket can be used in xsk_umem__create_opts() and later in
+xsk_socket__create() with created umem.  xsk_socket__create_shared() would
 still require privileges for AF_XDP socket creation.
 
 .SS "Data path"

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -350,7 +350,7 @@ struct xsk_umem *xsk_umem__create_opts(void *umem_area,
 	
 	mr_size = sizeof(mr);
 	/* Older kernels don't support tx_metadata_len, skip if we are not setting a value */
-	if(!mr.tx_metadata_len)
+	if (!mr.tx_metadata_len)
 		mr_size = offsetof(struct xdp_umem_reg, tx_metadata_len);
 	err = setsockopt(umem->fd, SOL_XDP, XDP_UMEM_REG, &mr, mr_size);
 	if (err) {
@@ -381,7 +381,7 @@ int xsk_umem__create_with_fd(struct xsk_umem **umem_ptr, int fd,
 {
 	struct xsk_umem *umem;
 
-	if(!umem_ptr)
+	if (!umem_ptr)
 		return -EFAULT;
 
 	DECLARE_LIBXDP_OPTS(xsk_umem_opts, opts,
@@ -396,7 +396,7 @@ int xsk_umem__create_with_fd(struct xsk_umem **umem_ptr, int fd,
 		opts.flags = usr_config->flags;
 	}
 	umem = xsk_umem__create_opts(umem_area, fill, comp, &opts);
-	if(!umem)
+	if (!umem)
 		return errno;
 	
 	*umem_ptr = umem;


### PR DESCRIPTION
Edit documentation for creating XSk umem by opts, with minor format fix.
This is a follow-up to the previous work [PR#443](https://github.com/xdp-project/xdp-tools/pull/443)