### PR TITLE
libxdp: Use opts to create XDP socket

### DIFF
--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -213,7 +213,7 @@ struct xsk_umem_config {
  *  If the remaining fields are unset, they will be set to 
  *  default value (see `xsk_set_umem_config()`).
  * 
- * Except for the fields mentioned above, none field can be set.
+ * Except for the fields mentioned above, no field can be set.
  */
 struct xsk_umem_opts {
 	size_t sz;
@@ -249,6 +249,40 @@ struct xsk_socket_config {
 	__u16 bind_flags;
 };
 
+/* 
+ * The following fields should not be NULL at the same time:
+ *
+ * @rx, @tx
+ *  At least one traffic direction should be assigned for an xsk.
+ * 
+ * The following fields are optional:
+ * 
+ * @fill, @comp, @rx_size, @tx_size, @libxdp_flags, @xdp_flags,
+ * @bind_flags
+ *  If a socket with exclusive ownership of a umem is going to be
+ *  created, keep @fill and @comp unset. If the umem is to be shared
+ *  with other sockets, set @fill and @comp to the corresponding
+ *  fields of the umem.
+ *  If the remaining fields are unset, they will be set to 
+ *  default value (see `xsk_set_xdp_socket_config()`).
+ * 
+ * Except for the fields mentioned above, no field can be set.
+ */
+struct xsk_socket_opts {
+	size_t sz;
+	struct xsk_ring_cons *rx;
+	struct xsk_ring_prod *tx;
+	struct xsk_ring_prod *fill;
+	struct xsk_ring_cons *comp;
+	__u32 rx_size;
+	__u32 tx_size;
+	__u32 libxdp_flags;
+	__u32 xdp_flags;
+	__u16 bind_flags;
+	size_t :0;
+};
+#define xsk_socket_opts__last_field bind_flags
+
 /* Set config to NULL to get the default configuration. */
 int xsk_umem__create(struct xsk_umem **umem,
 		     void *umem_area, __u64 size,
@@ -280,6 +314,11 @@ int xsk_socket__create_shared(struct xsk_socket **xsk_ptr,
 			      struct xsk_ring_prod *fill,
 			      struct xsk_ring_cons *comp,
 			      const struct xsk_socket_config *config);
+/* Newer version to create xsk by opts, recommended to use. */				  
+struct xsk_socket *xsk_socket__create_opts(const char *ifname,
+					   __u32 queue_id,
+					   struct xsk_umem *umem,
+					   struct xsk_socket_opts *opts);		  
 
 /* Returns 0 for success and -EBUSY if the umem is still in use. */
 int xsk_umem__delete(struct xsk_umem *umem);

--- a/lib/libxdp/libxdp.map
+++ b/lib/libxdp/libxdp.map
@@ -83,4 +83,5 @@ LIBXDP_1.4.0 {
 
 LIBXDP_1.5.0 {
 		xsk_umem__create_opts;
+		xsk_socket__create_opts;
 } LIBXDP_1.4.0;


### PR DESCRIPTION
Introduce a new API xsk_socket__create_opts() to create XDP socket using opts struct. Note that if one of fill and comp is unset, the semantic of the new API is the same as xsk_socket__create(), otherwise the same as xsk_socket__create_shared().