### PR TITLE
libxdp: Use opts-style API to create umem in libxdp tests

### DIFF
--- a/lib/libxdp/tests/test_xsk_refcnt.c
+++ b/lib/libxdp/tests/test_xsk_refcnt.c
@@ -107,16 +107,17 @@ static struct xsk_socket_info *xsks[MAX_NUM_QUEUES];
 static struct xsk_umem_info *xsk_configure_umem(void *buffer, u64 size)
 {
 	struct xsk_umem_info *umem;
-	int ret;
 
 	umem = calloc(1, sizeof(*umem));
 	if (!umem)
 		exit(EXIT_FAILURE);
 
-	ret = xsk_umem__create(&umem->umem, buffer, size, &umem->fq, &umem->cq,
-			       NULL);
-	if (ret)
-		exit(ret);
+	DECLARE_LIBXDP_OPTS(xsk_umem_opts, opts, 
+		.size = size,
+	);
+	umem->umem = xsk_umem__create_opts(buffer, &umem->fq, &umem->cq, &opts);
+	if (!umem->umem)
+		exit(errno);
 
 	umem->buffer = buffer;
 	return umem;


### PR DESCRIPTION
Use opts-style API to create umem in libxdp tests.
This is a follow-up to the previous work https://github.com/xdp-project/xdp-tools/pull/443