### PR TITLE
libxdp: Modify semantic of fill and comp in xsk_socket_opts, with tests edited

### DIFF
--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -259,10 +259,9 @@ struct xsk_socket_config {
  * 
  * @fill, @comp, @rx_size, @tx_size, @libxdp_flags, @xdp_flags,
  * @bind_flags
- *  If a socket with exclusive ownership of a umem is going to be
- *  created, keep @fill and @comp unset. If the umem is to be shared
- *  with other sockets, set @fill and @comp to the corresponding
- *  fields of the umem.
+ *  If @fill and @comp are both unset, fill_save and comp_save of
+ *  the umem will be assigned to them, otherwise keep what they
+ *  are set in opts.
  *  If the remaining fields are unset, they will be set to 
  *  default value (see `xsk_set_xdp_socket_config()`).
  * 

--- a/headers/xdp/xsk.h
+++ b/headers/xdp/xsk.h
@@ -259,9 +259,9 @@ struct xsk_socket_config {
  * 
  * @fill, @comp, @rx_size, @tx_size, @libxdp_flags, @xdp_flags,
  * @bind_flags
- *  If @fill and @comp are both unset, fill_save and comp_save of
- *  the umem will be assigned to them, otherwise keep what they
- *  are set in opts.
+ *  If @fill and @comp are both unset, they will be set to umem's
+ *  fill_save and comp_save respectively. Note that it is invalid
+ *  to set only one of them.
  *  If the remaining fields are unset, they will be set to 
  *  default value (see `xsk_set_xdp_socket_config()`).
  * 

--- a/lib/libxdp/tests/test_xsk_non_privileged.c
+++ b/lib/libxdp/tests/test_xsk_non_privileged.c
@@ -127,20 +127,22 @@ static struct xsk_socket *create_xsk_non_privileged(const char *ifname,
 						    struct xsk_umem *umem,
 						    int queue_id)
 {
-	struct xsk_socket_config cfg = {
+	struct xsk_socket *xsk = NULL;
+	struct xsk_ring_cons rx;
+	struct xsk_ring_prod tx;
+
+	DECLARE_LIBXDP_OPTS(xsk_socket_opts, opts, 
+		.rx = &rx,
+		.tx = &tx,
 		.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
 		.tx_size = XSK_RING_PROD__DEFAULT_NUM_DESCS,
 		.libxdp_flags = XSK_LIBXDP_FLAGS__INHIBIT_PROG_LOAD,
 		.bind_flags = XDP_USE_NEED_WAKEUP,
 		.xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST,
-	};
-	struct xsk_socket *xsk = NULL;
-	struct xsk_ring_cons rx;
-	struct xsk_ring_prod tx;
-
-	if (xsk_socket__create(&xsk, ifname, queue_id,
-			       umem, &rx, &tx, &cfg) || !xsk) {
-		perror("xsk_socket__create failed");
+	);
+	xsk = xsk_socket__create_opts(ifname, queue_id, umem, &opts);
+	if (!xsk) {
+		perror("xsk_socket__create_opts failed");
 		exit(EXIT_FAILURE);
 	}
 

--- a/lib/libxdp/tests/test_xsk_refcnt.c
+++ b/lib/libxdp/tests/test_xsk_refcnt.c
@@ -125,7 +125,6 @@ static struct xsk_umem_info *xsk_configure_umem(void *buffer, u64 size)
 static struct xsk_socket_info *xsk_configure_socket(struct xsk_umem_info *umem,
 						    unsigned int qid)
 {
-	struct xsk_socket_config cfg = {};
 	struct xsk_socket_info *xsk;
 	struct xsk_ring_cons *rxr;
 
@@ -134,11 +133,12 @@ static struct xsk_socket_info *xsk_configure_socket(struct xsk_umem_info *umem,
 		exit(EXIT_FAILURE);
 
 	xsk->umem = umem;
-	cfg.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS;
-
 	rxr = &xsk->rx;
-	xsk_socket__create(&xsk->xsk, opt_if, qid, umem->umem,
-			   rxr, NULL, &cfg);
+	DECLARE_LIBXDP_OPTS(xsk_socket_opts, opts, 
+		.rx = rxr,
+		.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
+	);
+	xsk->xsk = xsk_socket__create_opts(opt_if, qid, umem->umem, &opts);
 
 	return xsk;
 }

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -1072,12 +1072,16 @@ struct xsk_socket *xsk_socket__create_opts(const char *ifname,
 	}
 	rx = OPTS_GET(opts, rx, NULL);
 	tx = OPTS_GET(opts, tx, NULL);
-	fill = OPTS_GET(opts, fill, umem->fill_save);
-	comp = OPTS_GET(opts, comp, umem->comp_save);
+	fill = OPTS_GET(opts, fill, NULL);
+	comp = OPTS_GET(opts, comp, NULL);
 
 	if (!umem || !(rx || tx)) {
 		err = -EFAULT;
 		goto err;
+	}
+	if (!fill && !comp) {
+		fill = umem->fill_save;
+		comp = umem->comp_save;
 	}
 
 	xsk = calloc(1, sizeof(*xsk));

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -1075,7 +1075,7 @@ struct xsk_socket *xsk_socket__create_opts(const char *ifname,
 	fill = OPTS_GET(opts, fill, NULL);
 	comp = OPTS_GET(opts, comp, NULL);
 
-	if (!umem || !(rx || tx)) {
+	if (!umem || !(rx || tx) || (fill == NULL) ^ (comp == NULL)) {
 		err = -EFAULT;
 		goto err;
 	}


### PR DESCRIPTION
Use `umem`'s `fill_save` and `fill_comp` if `fill` and `comp` in opts are both unset when calling `xsk_socket__create_opts()`, otherwise use what they are set in opts. Add validation for only one of `fill` and `comp` are set.
This is to keep the same semantic as `xsk_socket__create()` and `xsk_socket__create_shared()`.
Also, use opts-style API to create XDP socket in libxdp tests.