### PR TITLE
xdp-trafficgen: fix typo in log message detected by Lintian

### DIFF
--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -296,7 +296,7 @@ static struct udp_packet *prepare_udp_pkt(const struct udpopt *cfg)
 	}
 
 	if (cfg->pkt_size < sizeof(*pkt)) {
-		pr_warn("Mininum packet size is %zu bytes\n", sizeof(*pkt));
+		pr_warn("Minimum packet size is %zu bytes\n", sizeof(*pkt));
 		goto err;
 	}
 


### PR DESCRIPTION
Fixes: 063ec71bea69 ("xdp-trafficgen: Support specifying the packet size for UDP packets")