### PR TITLE
xdpdump: A variable-sized type which should be placed at the end of a…

### DIFF
--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -192,8 +192,8 @@ static uint64_t get_if_speed(struct iface *iface)
 	int                                  fd;
 	struct ifreq                         ifr;
 	struct {
-		struct ethtool_link_settings req;
 		uint32_t                     modes[3 * MAX_MODE_MASKS];
+		struct ethtool_link_settings req;
 	} ereq;
 
 	if (iface == NULL)


### PR DESCRIPTION
… structure or union

if use -Werror,-Wgnu-variable-sized-type-not-at-end gnu flags in externel, will prevent compile code