### PR TITLE
Handle neighbour requests in xdp-filter

### DIFF
--- a/headers/xdp/parsing_helpers.h
+++ b/headers/xdp/parsing_helpers.h
@@ -52,6 +52,28 @@ struct icmphdr_common {
 	__sum16	cksum;
 };
 
+#define ARPHRD_ETHER 	1		/* Ethernet 10Mbps		*/
+#define	ARPOP_REQUEST	1		/* ARP request			*/
+#define	ARPOP_REPLY	2		/* ARP reply			*/
+
+struct arphdr {
+	__be16		ar_hrd;		/* format of hardware address	*/
+	__be16		ar_pro;		/* format of protocol address	*/
+	unsigned char	ar_hln;		/* length of hardware address	*/
+	unsigned char	ar_pln;		/* length of protocol address	*/
+	__be16		ar_op;		/* ARP opcode (command)		*/
+
+	 /*
+	  *	 Ethernet looks like this : This bit is variable sized however...
+	  */
+	unsigned char		ar_sha[ETH_ALEN];	/* sender hardware address	*/
+	__be32			ar_sip;		/* sender IP address		*/
+	unsigned char		ar_tha[ETH_ALEN];	/* target hardware address	*/
+	__be32			ar_tip;		/* target IP address		*/
+
+};
+
+
 /* Allow users of header file to redefine VLAN max depth */
 #ifndef VLAN_MAX_DEPTH
 #define VLAN_MAX_DEPTH 4
@@ -183,6 +205,29 @@ static __always_inline int parse_iphdr(struct hdr_cursor *nh,
 	*iphdr = iph;
 
 	return iph->protocol;
+}
+
+static __always_inline int parse_arphdr(struct hdr_cursor *nh,
+				       void *data_end,
+				       struct arphdr **arp_hdr)
+{
+	struct arphdr *arp = nh->pos;
+
+	if (arp + 1 > data_end)
+		return -1;
+
+	if (arp->ar_hrd != bpf_htons(ARPHRD_ETHER) ||
+	    arp->ar_pro != bpf_htons(ETH_P_IP) || arp->ar_hln != ETH_ALEN ||
+	    arp->ar_pln != 4 ||
+	    (arp->ar_op != bpf_htons(ARPOP_REPLY) &&
+	     arp->ar_op != bpf_htons(ARPOP_REQUEST)))
+		return -1;
+
+
+	nh->pos = (void *)(arp + 1);
+	*arp_hdr = arp;
+
+	return arp->ar_op;
 }
 
 static __always_inline int parse_icmp6hdr(struct hdr_cursor *nh,

--- a/xdp-filter/xdpfilt_prog.h
+++ b/xdp-filter/xdpfilt_prog.h
@@ -44,6 +44,12 @@
 			goto out;                                            \
 	} while (0)
 
+#define CHECK_VERDICT_2(type, param1, param2)					\
+	do {                                                                 \
+		if ((action = lookup_verdict_##type(param1, param2)) != VERDICT_MISS) \
+			goto out;                                            \
+	} while (0)
+
 #define CHECK_MAP(map, key, mask)                               \
 	do {                                                    \
 		__u64 *value;                                   \
@@ -109,21 +115,26 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } MAP_NAME_IPV4 SEC(".maps");
 
-static int __always_inline lookup_verdict_ipv4(struct iphdr *iphdr)
+static int __always_inline lookup_verdict_ipv4(__u32 *src_addr, __u32 *dst_addr)
 {
 	__u32 addr;
-	addr = iphdr->daddr;
-	CHECK_MAP(&filter_ipv4, &addr, MAP_FLAG_DST);
-	addr = iphdr->saddr;
-	CHECK_MAP(&filter_ipv4, &addr, MAP_FLAG_SRC);
+
+	if (dst_addr) {
+		addr = *dst_addr;
+		CHECK_MAP(&filter_ipv4, &addr, MAP_FLAG_DST);
+	}
+	if (src_addr) {
+		addr = *src_addr;
+		CHECK_MAP(&filter_ipv4, &addr, MAP_FLAG_SRC);
+	}
 	return VERDICT_MISS;
 }
 
-#define CHECK_VERDICT_IPV4(param) CHECK_VERDICT(ipv4, param)
+#define CHECK_VERDICT_IPV4(src, dst) CHECK_VERDICT_2(ipv4, src, dst)
 #define FEATURE_IPV4 FEAT_IPV4
 #else
 #define FEATURE_IPV4 0
-#define CHECK_VERDICT_IPV4(param)
+#define CHECK_VERDICT_IPV4(src, dst)
 #endif /* FILT_MODE_IPV4 */
 
 #ifdef FILT_MODE_IPV6
@@ -210,14 +221,28 @@ int FUNCNAME(struct xdp_md *ctx)
 
 #if defined(FILT_MODE_IPV4) || defined(FILT_MODE_IPV6) || \
 	defined(FILT_MODE_TCP) || defined(FILT_MODE_UDP)
-	struct iphdr *iphdr;
 	struct ipv6hdr *ipv6hdr;
-	int ip_type;
+	struct arphdr *arphdr;
+	struct iphdr *iphdr;
+	int ip_type = 0, nh_op;
 	if (eth_type == bpf_htons(ETH_P_IP)) {
 		ip_type = parse_iphdr(&nh, data_end, &iphdr);
 		CHECK_RET(ip_type);
 
-		CHECK_VERDICT_IPV4(iphdr);
+		CHECK_VERDICT_IPV4(&iphdr->saddr, &iphdr->daddr);
+	} else if (eth_type == bpf_htons(ETH_P_ARP)) {
+		nh_op = parse_arphdr(&nh, data_end, &arphdr);
+		CHECK_RET(nh_op);
+
+		// Always check the verdict of the ARP sender
+		CHECK_VERDICT_IPV4(&arphdr->ar_sip, NULL);
+		if (nh_op == bpf_htons(ARPOP_REQUEST)) {
+			// Someone wants to talk to TARGET, so target is a DST IP
+			CHECK_VERDICT_IPV4(NULL, &arphdr->ar_tip);
+		} else {
+			// Someone at has addr TARGET, so target is a SRC IP
+			CHECK_VERDICT_IPV4(&arphdr->ar_tip, NULL);
+		}
 	} else if (eth_type == bpf_htons(ETH_P_IPV6)) {
 		ip_type = parse_ip6hdr(&nh, data_end, &ipv6hdr);
 		CHECK_RET(ip_type);

--- a/xdp-filter/xdpfilt_prog.h
+++ b/xdp-filter/xdpfilt_prog.h
@@ -14,6 +14,9 @@
 #include <bpf/bpf_helpers.h>
 #include <xdp/xdp_helpers.h>
 
+#define NDISC_NEIGHBOUR_SOLICITATION	135
+#define NDISC_NEIGHBOUR_ADVERTISEMENT	136
+
 #include "common_kern_user.h"
 
 /* Defines xdp_stats_map */
@@ -146,22 +149,26 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } MAP_NAME_IPV6 SEC(".maps");
 
-static int __always_inline lookup_verdict_ipv6(struct ipv6hdr *ipv6hdr)
+static int __always_inline lookup_verdict_ipv6(struct in6_addr *src_addr, struct in6_addr *dst_addr)
 {
 	struct in6_addr addr;
 
-	addr = ipv6hdr->daddr;
-	CHECK_MAP(&filter_ipv6, &addr, MAP_FLAG_DST);
-	addr = ipv6hdr->saddr;
-	CHECK_MAP(&filter_ipv6, &addr, MAP_FLAG_SRC);
+	if (dst_addr) {
+		addr = *dst_addr;
+		CHECK_MAP(&filter_ipv6, &addr, MAP_FLAG_DST);
+	}
+	if (src_addr) {
+		addr = *src_addr;
+		CHECK_MAP(&filter_ipv6, &addr, MAP_FLAG_SRC);
+	}
 	return VERDICT_MISS;
 }
 
-#define CHECK_VERDICT_IPV6(param) CHECK_VERDICT(ipv6, param)
+#define CHECK_VERDICT_IPV6(src, dst) CHECK_VERDICT_2(ipv6, src, dst)
 #define FEATURE_IPV6 FEAT_IPV6
 #else
 #define FEATURE_IPV6 0
-#define CHECK_VERDICT_IPV6(param)
+#define CHECK_VERDICT_IPV6(src, dst)
 #endif /* FILT_MODE_IPV6 */
 
 #ifdef FILT_MODE_ETHERNET
@@ -221,6 +228,7 @@ int FUNCNAME(struct xdp_md *ctx)
 
 #if defined(FILT_MODE_IPV4) || defined(FILT_MODE_IPV6) || \
 	defined(FILT_MODE_TCP) || defined(FILT_MODE_UDP)
+	struct icmp6hdr *icmp6hdr;
 	struct ipv6hdr *ipv6hdr;
 	struct arphdr *arphdr;
 	struct iphdr *iphdr;
@@ -247,7 +255,26 @@ int FUNCNAME(struct xdp_md *ctx)
 		ip_type = parse_ip6hdr(&nh, data_end, &ipv6hdr);
 		CHECK_RET(ip_type);
 
-		CHECK_VERDICT_IPV6(ipv6hdr);
+		CHECK_VERDICT_IPV6(&ipv6hdr->saddr, &ipv6hdr->daddr);
+
+		if (ip_type == IPPROTO_ICMPV6) {
+			nh_op = parse_icmp6hdr(&nh, data_end, &icmp6hdr);
+			CHECK_RET(nh_op);
+
+			if (nh_op == NDISC_NEIGHBOUR_SOLICITATION ||
+			    nh_op == NDISC_NEIGHBOUR_ADVERTISEMENT) {
+				struct in6_addr *addr = nh.pos;
+
+				if (addr + 1 > data_end) {
+					action = XDP_ABORTED;
+					goto out;
+				}
+				if (nh_op == NDISC_NEIGHBOUR_SOLICITATION)
+					CHECK_VERDICT_IPV6(NULL, addr);
+				else
+					CHECK_VERDICT_IPV6(addr, NULL);
+			}
+		}
 	} else {
 		goto out;
 	}


### PR DESCRIPTION
When using IP filter mode in xdp-filter, we don't parse neighbour requests (ARP
for IPv4, ND ICMPv6 packets for IPv6), which can lead to loss of connectivity in
deny-default mode. Add parsing of both types of neighbour packets and pass them
through the requisite filters.