### PR TITLE
Fix sample PPS report with longer poll intervals

### DIFF
--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -1542,7 +1542,7 @@ static int sample_timer_cb(int timerfd, struct stats_record **rec,
 	return print_stats(rec, prev);
 }
 
-int sample_run(int interval, void (*post_cb)(void *), void *ctx)
+int sample_run(unsigned int interval, void (*post_cb)(void *), void *ctx)
 {
 	struct timespec ts = { interval, 0 };
 	struct itimerspec its = { ts, ts };

--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -568,6 +568,16 @@ static __u64 calc_pps(struct datarec *r, struct datarec *p, double period_)
 	return pps;
 }
 
+static __u64 calc_pkts(struct datarec *r, struct datarec *p, double period_)
+{
+	__u64 packets = 0;
+
+	if (period_ > 0) {
+		packets = r->processed - p->processed;
+	}
+	return packets;
+}
+
 static __u64 calc_drop_pps(struct datarec *r, struct datarec *p, double period_)
 {
 	__u64 packets = 0;
@@ -580,6 +590,16 @@ static __u64 calc_drop_pps(struct datarec *r, struct datarec *p, double period_)
 	return pps;
 }
 
+static __u64 calc_drop_pkts(struct datarec *r, struct datarec *p, double period_)
+{
+	__u64 packets = 0;
+
+	if (period_ > 0) {
+		packets = r->dropped - p->dropped;
+	}
+	return packets;
+}
+
 static __u64 calc_errs_pps(struct datarec *r, struct datarec *p, double period_)
 {
 	__u64 packets = 0;
@@ -590,6 +610,16 @@ static __u64 calc_errs_pps(struct datarec *r, struct datarec *p, double period_)
 		pps = sample_round(packets / period_);
 	}
 	return pps;
+}
+
+static __u64 calc_errs_pkts(struct datarec *r, struct datarec *p, double period_)
+{
+	__u64 packets = 0;
+
+	if (period_ > 0) {
+		packets = r->issue - p->issue;
+	}
+	return packets;
 }
 
 static __u64 calc_info_pps(struct datarec *r, struct datarec *p, double period_)
@@ -645,16 +675,13 @@ static void stats_get_rx_cnt(struct stats_record *stats_rec,
 	}
 
 	if (out) {
-		pps = calc_pps(&rec->total, &prev->total, t);
-		drop = calc_drop_pps(&rec->total, &prev->total, t);
-		err = calc_errs_pps(&rec->total, &prev->total, t);
+		out->rx_cnt.pps = calc_pps(&rec->total, &prev->total, t);
+		out->rx_cnt.drop = calc_drop_pps(&rec->total, &prev->total, t);
+		out->rx_cnt.err = calc_errs_pps(&rec->total, &prev->total, t);
 
-		out->rx_cnt.pps = pps;
-		out->rx_cnt.drop = drop;
-		out->rx_cnt.err = err;
-		out->totals.rx += pps;
-		out->totals.drop += drop;
-		out->totals.err += err;
+		out->totals.rx += calc_pkts(&rec->total, &prev->total, t);
+		out->totals.drop += calc_drop_pkts(&rec->total, &prev->total, t);
+		out->totals.err += calc_errs_pkts(&rec->total, &prev->total, t);
 	}
 }
 
@@ -845,9 +872,8 @@ static void stats_get_redirect_cnt(struct stats_record *stats_rec,
 	}
 
 	if (out) {
-		pps = calc_pps(&rec->total, &prev->total, t);
-		out->redir_cnt.suc = pps;
-		out->totals.redir += pps;
+		out->redir_cnt.suc = calc_pps(&rec->total, &prev->total, t);
+		out->totals.redir += calc_pkts(&rec->total, &prev->total, t);
 	}
 }
 
@@ -856,8 +882,8 @@ static void stats_get_redirect_err_cnt(struct stats_record *stats_rec,
 				       int nr_cpus,
 				       struct sample_output *out)
 {
+	double t, drop, sum_pps = 0, sum_pkts = 0;
 	struct record *rec, *prev;
-	double t, drop, sum = 0;
 	int rec_i, i;
 
 	for (rec_i = 1; rec_i < XDP_REDIRECT_ERR_MAX; rec_i++) {
@@ -891,12 +917,13 @@ static void stats_get_redirect_err_cnt(struct stats_record *stats_rec,
 				      ERR(drop));
 		}
 
-		sum += drop;
+		sum_pps += drop;
+		sum_pkts += calc_drop_pkts(&rec->total, &prev->total, t);
 	}
 
 	if (out) {
-		out->redir_cnt.err = sum;
-		out->totals.err += sum;
+		out->redir_cnt.err = sum_pps;
+		out->totals.err += sum_pkts;
 	}
 }
 
@@ -905,7 +932,7 @@ static void stats_get_exception_cnt(struct stats_record *stats_rec,
 				    int nr_cpus,
 				    struct sample_output *out)
 {
-	double t, drop, sum = 0;
+	double t, drop, sum_pps = 0, sum_pkts = 0;
 	struct record *rec, *prev;
 	int rec_i, i;
 
@@ -915,9 +942,10 @@ static void stats_get_exception_cnt(struct stats_record *stats_rec,
 		t = calc_period(rec, prev);
 
 		drop = calc_drop_pps(&rec->total, &prev->total, t);
-		/* Fold out errors after heading */
-		sum += drop;
+		sum_pps += drop;
+		sum_pkts += calc_drop_pkts(&rec->total, &prev->total, t);
 
+		/* Fold out errors after heading */
 		if (drop > 0 && !out) {
 			print_always("    %-18s " FMT_COLUMNf "\n",
 				     xdp_action2str(rec_i), ERR(drop));
@@ -940,8 +968,8 @@ static void stats_get_exception_cnt(struct stats_record *stats_rec,
 	}
 
 	if (out) {
-		out->except_cnt.hits = sum;
-		out->totals.err += sum;
+		out->except_cnt.hits = sum_pps;
+		out->totals.err += sum_pkts;
 	}
 }
 
@@ -982,18 +1010,18 @@ static void stats_get_devmap_xmit(struct stats_record *stats_rec,
 	if (out) {
 		pps = calc_pps(&rec->total, &prev->total, t);
 		drop = calc_drop_pps(&rec->total, &prev->total, t);
+
 		info = calc_info_pps(&rec->total, &prev->total, t);
 		if (info > 0)
-			info = (pps + drop) / info; /* calc avg bulk */
-		err = calc_errs_pps(&rec->total, &prev->total, t);
+			out->xmit_cnt.bavg = (pps + drop) / info; /* calc avg bulk */
 
 		out->xmit_cnt.pps = pps;
 		out->xmit_cnt.drop = drop;
-		out->xmit_cnt.bavg = info;
-		out->xmit_cnt.err = err;
-		out->totals.xmit += pps;
-		out->totals.drop_xmit += drop;
-		out->totals.err += err;
+		out->xmit_cnt.err = calc_errs_pps(&rec->total, &prev->total, t);
+
+		out->totals.xmit += calc_pkts(&rec->total, &prev->total, t);
+		out->totals.drop_xmit += calc_drop_pkts(&rec->total, &prev->total, t);;
+		out->totals.err += calc_errs_pkts(&rec->total, &prev->total, t);;
 	}
 }
 
@@ -1041,20 +1069,21 @@ static void stats_get_devmap_xmit_multi(struct stats_record *stats_rec,
 		else
 			p = &beg;
 		t = calc_period(r, p);
+
+		if (out) {
+			/* We are responsible for filling out totals */
+			out->totals.xmit += calc_pkts(&r->total, &p->total, t);
+			out->totals.drop_xmit += calc_drop_pkts(&r->total, &p->total, t);
+			out->totals.err += calc_errs_pkts(&r->total, &p->total, t);
+			continue;
+		}
+
 		pps = calc_pps(&r->total, &p->total, t);
 		drop = calc_drop_pps(&r->total, &p->total, t);
 		info = calc_info_pps(&r->total, &p->total, t);
 		if (info > 0)
 			info = (pps + drop) / info; /* calc avg bulk */
 		err = calc_errs_pps(&r->total, &p->total, t);
-
-		if (out) {
-			/* We are responsible for filling out totals */
-			out->totals.xmit += pps;
-			out->totals.drop_xmit += drop;
-			out->totals.err += err;
-			continue;
-		}
 
 		fstr = tstr = NULL;
 		if (if_indextoname(from_idx, ifname_from))

--- a/lib/util/xdp_sample.c
+++ b/lib/util/xdp_sample.c
@@ -549,13 +549,6 @@ static double calc_period(struct record *r, struct record *p)
 	return period_;
 }
 
-static double sample_round(double val)
-{
-	if (val - floor(val) < 0.5)
-		return floor(val);
-	return ceil(val);
-}
-
 static __u64 calc_pps(struct datarec *r, struct datarec *p, double period_)
 {
 	__u64 packets = 0;
@@ -563,7 +556,7 @@ static __u64 calc_pps(struct datarec *r, struct datarec *p, double period_)
 
 	if (period_ > 0) {
 		packets = r->processed - p->processed;
-		pps = sample_round(packets / period_);
+		pps = round(packets / period_);
 	}
 	return pps;
 }
@@ -585,7 +578,7 @@ static __u64 calc_drop_pps(struct datarec *r, struct datarec *p, double period_)
 
 	if (period_ > 0) {
 		packets = r->dropped - p->dropped;
-		pps = sample_round(packets / period_);
+		pps = round(packets / period_);
 	}
 	return pps;
 }
@@ -607,7 +600,7 @@ static __u64 calc_errs_pps(struct datarec *r, struct datarec *p, double period_)
 
 	if (period_ > 0) {
 		packets = r->issue - p->issue;
-		pps = sample_round(packets / period_);
+		pps = round(packets / period_);
 	}
 	return pps;
 }
@@ -629,7 +622,7 @@ static __u64 calc_info_pps(struct datarec *r, struct datarec *p, double period_)
 
 	if (period_ > 0) {
 		packets = r->info - p->info;
-		pps = sample_round(packets / period_);
+		pps = round(packets / period_);
 	}
 	return pps;
 }
@@ -1354,7 +1347,7 @@ static void sample_summary_print(void)
 		print_always("  Packets received    : %'-10" PRIu64 "\n",
 			     (uint64_t)sample_out.totals.rx);
 		print_always("  Average packets/s   : %'-10.0f\n",
-			     sample_round(pkts / num));
+			     round(pkts / num));
 	}
 	if (sample_out.totals.redir) {
 		double pkts = sample_out.totals.redir;
@@ -1362,7 +1355,7 @@ static void sample_summary_print(void)
 		print_always("  Packets redirected  : %'-10" PRIu64 "\n",
 			     sample_out.totals.redir);
 		print_always("  Average redir/s     : %'-10.0f\n",
-			     sample_round(pkts / num));
+			     round(pkts / num));
 	}
 	if (sample_out.totals.drop)
 		print_always("  Rx dropped          : %'-10" PRIu64 "\n",
@@ -1379,7 +1372,7 @@ static void sample_summary_print(void)
 		print_always("  Packets transmitted : %'-10" PRIu64 "\n",
 			     sample_out.totals.xmit);
 		print_always("  Average transmit/s  : %'-10.0f\n",
-			     sample_round(pkts / num));
+			     round(pkts / num));
 	}
 }
 

--- a/lib/util/xdp_sample.h
+++ b/lib/util/xdp_sample.h
@@ -42,7 +42,7 @@ enum sample_compat {
 int sample_setup_maps(struct bpf_map **maps, const char *ifname);
 int __sample_init(int mask, int ifindex_from, int ifindex_to);
 void sample_teardown(void);
-int sample_run(int interval, void (*post_cb)(void *), void *ctx);
+int sample_run(unsigned int interval, void (*post_cb)(void *), void *ctx);
 bool sample_is_compat(enum sample_compat compat_value);
 bool sample_probe_cpumap_compat(void);
 bool sample_probe_xdp_load_bytes(void);


### PR DESCRIPTION
The PPS values in xdp_sample output were calculated incorrectly if the reporting
interval is longer than one second. Fix this by reworking the accounting to
calculate packet and PPS values separately and printing the right values as
appropriate.