### PR TITLE
Explicitly set PREFIX=/ when installing embedded libbpf headers

### DIFF
--- a/configure
+++ b/configure
@@ -379,7 +379,7 @@ EOF
         fi
 
         LIBBPF_VERSION=$(get_libbpf_version "lib/libbpf/src")
-        LIBBPF_INCLUDE_DIR='$(LIB_DIR)/libbpf/src/root/usr/include'
+        LIBBPF_INCLUDE_DIR='$(LIB_DIR)/libbpf/src/root/include'
         LIBBPF_LIB_DIR='$(LIB_DIR)/libbpf/src'
         OBJECT_LIBBPF="${LIBBPF_LIB_DIR}/libbpf.a"
         echo "submodule v$LIBBPF_VERSION"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -48,7 +48,7 @@ LIBBPF_SOURCES := $(wildcard libbpf/src/*.[ch])
 libbpf/src/libbpf.a: $(LIBBPF_SOURCES)
 	@echo ; echo "  libbpf"
 	$(QUIET_CC)$(MAKE) -C libbpf/src CFLAGS="$(LIBBPF_CFLAGS)" $P
-	$(QUIET_INSTALL)$(MAKE) -C libbpf/src install_headers DESTDIR=root $P
+	$(QUIET_INSTALL)$(MAKE) -C libbpf/src install_headers DESTDIR=root PREFIX=/ $P
 
 libbpf_clean:
 	$(Q)$(MAKE) -C libbpf/src clean $P


### PR DESCRIPTION
When xdp-tools builds the embedded copy of libbpf, it invokes the libbpf build system to installs it headers, and then constructs a path to those embedded libbpf headers based on the assumption that libbpf installed its headers into its default PREFIX (which appears to be /usr):

https://github.com/xdp-project/xdp-tools/blob/7b3bbe2f6f16d658bb09a7b7e5958f4a49825ee6/configure#L382

However, if PREFIX is passed to the xdp-tools build system, this variable gets passed down to the invocation of the libbpf build system as well, and libbpf installs its headers into a different directory that doesn't match xdp-tools' LIBBPF_INCLUDE_DIR variable, and the build fails like this:

    $ make PREFIX=/usr/local
    […]
    libbpf support: Submodule 'libbpf' (https://github.com/libbpf/libbpf.git) registered for path 'lib/libbpf'
    Cloning into '/home/edmonds/src/xdp-tools/lib/libbpf'...
    Submodule path 'lib/libbpf': checked out 'fdf402b384cc42ce29bb9e27011633be3cbafe1e'
    submodule v1.4.0
    […]
    lib

      libbpf
        CC       libbpf/src/libbpf.a
        INSTALL  libbpf/src/libbpf.a

      libxdp
        CC       staticobjs/libxdp.o
    libxdp.c:31:10: fatal error: bpf/libbpf.h: No such file or directory
       31 | #include <bpf/libbpf.h>
          |          ^~~~~~~~~~~~~~
    compilation terminated.

This commit explicitly passes PREFIX=/usr to the libbpf build system when installing the embedded libbpf headers so that xdp-tools' LIBBPF_INCLUDE_DIR variable still matches the path to those headers.