### PR TITLE
libxdp: Fix incorrect setsockopt xdp_umem_reg size.

### DIFF
--- a/lib/libxdp/tests/.gitignore
+++ b/lib/libxdp/tests/.gitignore
@@ -4,3 +4,4 @@ test_xdp_frags
 test_dispatcher_versions
 test_xsk_non_privileged
 test_link_detach
+test_xsk_umem_flags

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags test_dispatcher_versions test_link_detach
+USER_TARGETS := test_xsk_refcnt check_kern_compat test_xdp_frags test_dispatcher_versions test_link_detach test_xsk_umem_flags
 BPF_TARGETS := xdp_dispatcher_v1 xdp_pass
 USER_LIBS := -lpthread
 

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged test_link_detach"
+ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged test_link_detach test_xsk_umem_flags"
 
 TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
@@ -109,6 +109,13 @@ test_link_detach()
 	fi
 	ip link add xdp_veth0 type veth peer name xdp_veth1
 	check_run $TESTS_DIR/test_link_detach xdp_veth0
+	ip link delete xdp_veth0
+}
+
+test_xsk_umem_flags()
+{
+	ip link add xdp_veth0 type veth peer name xdp_veth1
+	check_run $TESTS_DIR/test_xsk_umem_flags xdp_veth0
 	ip link delete xdp_veth0
 }
 

--- a/lib/libxdp/tests/test_xsk_umem_flags.c
+++ b/lib/libxdp/tests/test_xsk_umem_flags.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+#include <errno.h>
+#include <inttypes.h>
+#include <linux/if_link.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+
+#include <bpf/bpf.h>
+#include <xdp/xsk.h>
+
+#define NUM_DESCS ((XSK_RING_PROD__DEFAULT_NUM_DESCS \
+			+ XSK_RING_CONS__DEFAULT_NUM_DESCS) * 2)
+#define UMEM_SIZE (NUM_DESCS * XSK_UMEM__DEFAULT_FRAME_SIZE)
+
+static void update_rlimit_memlock(void)
+{
+	struct rlimit rlim = { .rlim_cur = UMEM_SIZE, .rlim_max = UMEM_SIZE };
+
+	if (setrlimit(RLIMIT_MEMLOCK, &rlim)) {
+		perror("setrlimit(RLIMIT_MEMLOCK) failed");
+		exit(EXIT_FAILURE);
+	}
+}
+
+static struct xsk_umem *create_umem_with_flags()
+{
+	struct xsk_umem *umem = NULL;
+	struct xsk_ring_cons cq;
+	struct xsk_ring_prod fq;
+	void *b;
+
+	if (posix_memalign(&b, getpagesize(), UMEM_SIZE)) {
+		perror("posix_memalign failed");
+		exit(EXIT_FAILURE);
+	}
+
+	/* This variant uses a frame_size that is not a power of 2 without
+	 * flags, should fail. */
+	DECLARE_LIBXDP_OPTS(xsk_umem_opts, opts_no_flags,
+		.size = UMEM_SIZE - 1,
+		.fill_size = XSK_RING_PROD__DEFAULT_NUM_DESCS,
+		.comp_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
+		.frame_size = XSK_UMEM__DEFAULT_FRAME_SIZE - 1,
+	);
+	umem = xsk_umem__create_opts(b, &fq, &cq, &opts_no_flags);
+	if (umem) {
+		perror("xsk_umem__create_opts with odd frame_size "
+		       "unexpectedly succeeded");
+		exit(EXIT_FAILURE);
+	}
+
+	/* This variant uses a frame_size that is not a power of 2 with flags,
+	 * should succeed.
+	 *
+	 * A failure here may indicate a mismatch in struct xdp_umem_reg
+	 * between user space and kernel space, and that fall back processing
+	 * is happening in the kernel. (Ref: LP: #2098005 and PR #477).
+	 */
+	DECLARE_LIBXDP_OPTS(xsk_umem_opts, opts,
+		.size = UMEM_SIZE - 1,
+		.fill_size = XSK_RING_PROD__DEFAULT_NUM_DESCS,
+		.comp_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
+		.frame_size = XSK_UMEM__DEFAULT_FRAME_SIZE - 1,
+		.flags = XDP_UMEM_UNALIGNED_CHUNK_FLAG,
+	);
+	umem = xsk_umem__create_opts(b, &fq, &cq, &opts);
+	if (!umem) {
+		perror("xsk_umem__create_opts failed");
+		exit(EXIT_FAILURE);
+	}
+
+	return umem;
+}
+
+static struct xsk_socket *create_xsk(const char *ifname, struct xsk_umem *umem,
+				     int queue_id)
+{
+	struct xsk_socket *xsk = NULL;
+	struct xsk_ring_cons rx;
+	struct xsk_ring_prod tx;
+
+	DECLARE_LIBXDP_OPTS(xsk_socket_opts, opts,
+		.rx = &rx,
+		.tx = &tx,
+		.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
+		.tx_size = XSK_RING_PROD__DEFAULT_NUM_DESCS,
+		.libxdp_flags = XSK_LIBXDP_FLAGS__INHIBIT_PROG_LOAD,
+		.bind_flags = XDP_USE_NEED_WAKEUP,
+		.xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST,
+	);
+	xsk = xsk_socket__create_opts(ifname, queue_id, umem, &opts);
+	if (!xsk) {
+		perror("xsk_socket__create_opts failed");
+		exit(EXIT_FAILURE);
+	}
+
+	return xsk;
+}
+
+int main(int argc, const char *argv[])
+{
+	struct xsk_socket *xsk;
+	struct xsk_umem *umem;
+	int ifindex, queue_id;
+	const char *ifname;
+
+	silence_libbpf_logging();
+
+	if (argc < 2) {
+		printf("Usage: %s <interface>\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	update_rlimit_memlock();
+
+	ifname = argv[1];
+	queue_id = 0;
+
+	ifindex = if_nametoindex(ifname);
+	if (!ifindex) {
+		perror("if_nametoindex(ifname) failed");
+		exit(EXIT_FAILURE);
+	}
+
+	umem = create_umem_with_flags();
+	xsk = create_xsk(ifname, umem, queue_id);
+
+	xsk_socket__delete(xsk);
+
+	return EXIT_SUCCESS;
+}

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -297,7 +297,6 @@ struct xsk_umem *xsk_umem__create_opts(void *umem_area,
 				       struct xsk_umem_opts *opts) {
 	struct xdp_umem_reg mr;
 	struct xsk_umem *umem;
-	size_t mr_size;
 	int err, fd;
 	__u64 size;
 	
@@ -342,11 +341,7 @@ struct xsk_umem *xsk_umem__create_opts(void *umem_area,
 	mr.flags = umem->config.flags;
 	mr.tx_metadata_len = OPTS_GET(opts, tx_metadata_len, XSK_UMEM__DEFAULT_TX_METADATA_LEN);
 	
-	mr_size = sizeof(mr);
-	/* Older kernels don't support tx_metadata_len, skip if we are not setting a value */
-	if (!mr.tx_metadata_len)
-		mr_size = offsetof(struct xdp_umem_reg, tx_metadata_len);
-	err = setsockopt(umem->fd, SOL_XDP, XDP_UMEM_REG, &mr, mr_size);
+	err = setsockopt(umem->fd, SOL_XDP, XDP_UMEM_REG, &mr, sizeof(mr));
 	if (err) {
 		err = -errno;
 		goto out_socket;


### PR DESCRIPTION
The commit in the fixes tag made an uneccesary and incorrect attempt at backwards compatibility with kernels that do not support tx_metadata_len.

The kernel will either expect a size matching its version of struct xdp_umem_reg, if it encounters a shorter size, clamp it to 24 byte struct xdp_umem_reg_v1 [0].

The code in question attempted to provide a 28 byte length when tx_metadata_len was not set, which would invoke the kernel v1 processing.

This causes issues downstream as revealed in the Open vSwitch system testsuite.

I have confirmed that by removing this conditional, the test passes both on 6.7 and newer kernels.

0: https://github.com/torvalds/linux/blob/0ad2507d5d93/net/xdp/xsk.c#L1369-L1372
Fixes: 44b5e00692db ("libxdp: Add tx_metadata_len/xsk_umem__create_opts() to support AF_XDP Tx metadata")
Reported-at: https://launchpad.net/bugs/2098005
Signed-off-by: Frode Nordahl <fnordahl@ubuntu.com>