### PR TITLE
buildsystem: honour OBJDIR

### DIFF
--- a/lib/common.mk
+++ b/lib/common.mk
@@ -38,12 +38,12 @@ LIB_OBJS += $(foreach obj,$(UTIL_OBJS),$(LIB_DIR)/util/$(obj))
 EXTRA_DEPS +=
 EXTRA_USER_DEPS +=
 
-LDFLAGS+=-L$(LIBXDP_DIR)
+LDFLAGS+=-L$(LIBXDP_DIR)/$(OBJDIR)
 ifeq ($(DYNAMIC_LIBXDP),1)
 	LDLIBS:=-lxdp $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.so.$(LIBXDP_VERSION)
 else
-	LDLIBS:=-l:libxdp.a $(LDLIBS)
+	LDLIBS:=-l:$(OBJDIR)/libxdp.a $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.a
 endif
 

--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -25,12 +25,12 @@ USER_C := ${USER_TARGETS:=.c}
 USER_OBJ := ${USER_C:.c=.o}
 BPF_OBJS := $(BPF_TARGETS:=.o)
 
-LDFLAGS+=-L$(LIBXDP_DIR)
+LDFLAGS+=-L$(LIBXDP_DIR)/$(OBJDIR)
 ifeq ($(DYNAMIC_LIBXDP),1)
 	LDLIBS:=-lxdp $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.so.$(LIBXDP_VERSION)
 else
-	LDLIBS:=-l:libxdp.a $(LDLIBS)
+	LDLIBS:=-l:$(OBJDIR)/libxdp.a $(LDLIBS)
 	OBJECT_LIBXDP:=$(LIBXDP_DIR)/libxdp.a
 endif
 
@@ -83,4 +83,4 @@ $(BPF_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK) $(EXTRA_DEPS)
 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
 
 run: all
-	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" V=$(V) $(TEST_RUNNER) $(TEST_FILE) $(RUN_TESTS)
+	$(Q)env CC="$(CC)" CFLAGS="$(CFLAGS) $(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDLIBS="$(LDLIBS)" OBJDIR="$(OBJDIR)" V=$(V) $(TEST_RUNNER) $(TEST_FILE) $(RUN_TESTS)

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 EOF
-        $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -l:libxdp.a $LDLIBS 2>&1
+        $CC -o $TMPDIR/libxdptest $TMPDIR/libxdptest.c $CFLAGS $CPPFLAGS -l:$OBJDIR/libxdp.a $LDLIBS 2>&1
         retval=$?
         rm -rf "$TMPDIR"
         return $retval

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -99,7 +99,7 @@ usage()
 
 if [ "$EUID" -ne "0" ]; then
     if command -v sudo >/dev/null 2>&1; then
-        exec sudo env CC="$CC" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" LDLIBS="$LDLIBS" V=${VERBOSE_TESTS} "$0" "$@"
+        exec sudo env CC="$CC" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" LDLIBS="$LDLIBS" OBJDIR="$OBJDIR" V=${VERBOSE_TESTS} "$0" "$@"
     else
         die "Tests must be run as root"
     fi


### PR DESCRIPTION
The lib/libxdp/Makefile supports setting of OBJDIR, the directory where compiled object are placed. However when set, linking fails.

Set OBJDIR and pass it down the tests, so that linking works if OBJDIR is set.