### PR TITLE
Increase MAX_CPUS to 512

### DIFF
--- a/xdp-dump/xdpdump.h
+++ b/xdp-dump/xdpdump.h
@@ -11,7 +11,7 @@
  ******************************************************************************/
 #define PERF_MAX_WAKEUP_EVENTS   64
 #define PERF_MMAP_PAGE_COUNT	256
-#define MAX_CPUS		256
+#define MAX_CPUS		512
 
 /******************************************************************************
  * General used macros


### PR DESCRIPTION
Increase MAX_CPUS from 256 to 512 to support higher cpu count systems.
Fixes #485 