### PR TITLE
lib/defines: Propagate include directories to BPF_CFLAGS

### DIFF
--- a/lib/defines.mk
+++ b/lib/defines.mk
@@ -43,7 +43,7 @@ endif
 DEFINES += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 
 CFLAGS += -std=gnu11 -Wextra -Werror $(DEFINES) $(ARCH_INCLUDES)
-BPF_CFLAGS += $(DEFINES) $(filter -ffile-prefix-map=%,$(CFLAGS)) $(ARCH_INCLUDES)
+BPF_CFLAGS += $(DEFINES) $(filter -ffile-prefix-map=%,$(CFLAGS)) $(filter -I%,$(CFLAGS)) $(ARCH_INCLUDES)
 
 CONFIGMK := $(LIB_DIR)/../config.mk
 LIBMK := Makefile $(CONFIGMK) $(LIB_DIR)/defines.mk $(LIB_DIR)/common.mk $(LIB_DIR)/../version.mk


### PR DESCRIPTION
The configure script may add extra include directories to CFLAGS, but
these were not propagated to BPF_CFLAGS, which leads to build errors
when libbpf is in an unusual place. Add an explicit propagation of
any CFLAGS starting with -I to BPF_CFLAGS.

Fixes #496