### PR TITLE
xdp-traffigen: Better handling of missing interface support

### DIFF
--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -852,3 +852,21 @@ int iface_print_status(const struct iface *iface)
 out:
 	return err;
 }
+
+int iface_get_xdp_feature_flags(int ifindex, __u64 *feature_flags)
+{
+#ifdef HAVE_LIBBPF_BPF_XDP_QUERY
+	LIBBPF_OPTS(bpf_xdp_query_opts, opts);
+	int err;
+
+	err = bpf_xdp_query(ifindex, 0, &opts);
+	if (err)
+		return err;
+
+	*feature_flags = opts.feature_flags;
+	return 0;
+#else
+	return -EOPNOTSUPP;
+#endif
+
+}

--- a/lib/util/util.h
+++ b/lib/util/util.h
@@ -93,5 +93,7 @@ int prog_lock_release(int lock_fd);
 
 const char *get_libbpf_version(void);
 int iface_print_status(const struct iface *iface);
+int iface_get_xdp_feature_flags(int ifindex, __u64 *feature_flags);
+
 
 #endif

--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -1023,14 +1023,25 @@ out:
 }
 
 static const struct probeopt {
+	struct iface iface;
 } defaults_probe = {};
 
-static struct prog_option probe_options[] = {};
+static struct prog_option probe_options[] = {
+	DEFINE_OPTION("interface", OPT_IFNAME, struct probeopt, iface,
+		      .metavar = "<ifname>",
+		      .short_opt = 'i',
+		      .help = "Probe features of device <ifname>"),
+};
 
-int do_probe(__unused const void *cfg, __unused const char *pin_root_path)
+int do_probe(const void *opt, __unused const char *pin_root_path)
 {
-	int err = probe_kernel_support();
+	const struct probeopt *cfg = opt;
+	int err;
 
+	if (cfg->iface.ifindex)
+		check_iface_support(&cfg->iface);
+
+	err = probe_kernel_support();
 	if (!err)
 		pr_info("Kernel supports live packet mode for XDP BPF_PROG_RUN.\n");
 	return err;

--- a/xdp-trafficgen/xdp_trafficgen.bpf.c
+++ b/xdp-trafficgen/xdp_trafficgen.bpf.c
@@ -356,3 +356,9 @@ out:
 ret:
 	return action;
 }
+
+SEC("xdp")
+int xdp_pass(struct xdp_md *ctx)
+{
+	return XDP_PASS;
+}


### PR DESCRIPTION
Add logic to xdp-trafficgen to load a dummy program to an interface if needed,
and to abort running if the interface doesn't support the `ndo_xdp_xmit()`
operation.

Fixes #354