### PR TITLE
xdp-filter: Disable Python tests

### DIFF
--- a/xdp-filter/tests/test-xdp-filter.sh
+++ b/xdp-filter/tests/test-xdp-filter.sh
@@ -1,6 +1,6 @@
 XDP_LOADER=${XDP_LOADER:-./xdp-loader}
 XDP_FILTER=${XDP_FILTER:-./xdp-filter}
-ALL_TESTS="test_load test_print test_output_remove test_ports_allow test_ports_deny test_ipv6_allow test_ipv6_deny test_ipv4_allow test_ipv4_deny test_ether_allow test_ether_deny test_python_basic test_python_slow"
+ALL_TESTS="test_load test_print test_output_remove test_ports_allow test_ports_deny test_ipv6_allow test_ipv6_deny test_ipv4_allow test_ipv4_deny test_ether_allow test_ether_deny"
 
 try_feat()
 {


### PR DESCRIPTION
The Python tests are failing due to what appears to be a bug in
pyroute2. Let's disable them for now.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>