### PR TITLE
install xdp_forward XDP bpf program

### DIFF
--- a/xdp-forward/Makefile
+++ b/xdp-forward/Makefile
@@ -3,8 +3,6 @@
 XDP_TARGETS := xdp_forward.bpf xdp_flowtable.bpf xdp_flowtable_sample.bpf
 BPF_SKEL_TARGETS := $(XDP_TARGETS)
 
-XDP_OBJ_INSTALL :=
-
 TOOL_NAME := xdp-forward
 MAN_PAGE := xdp-forward.8
 TEST_FILE := tests/test-xdp-forward.sh


### PR DESCRIPTION
`XDP_OBJ_INSTALL := `stops `make install` to install xdp_forward.bpf xdp_flowtable.bpf xdp_flowtable_sample.bpf program. for linux distribution, we need to install these bpf programs.