### PR TITLE
Add compatibility workaround for programs that invalidate the packet pointer

### DIFF
--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         KERNEL_VERSION:
+          - "6.14.7-200.fc41"
           - "6.13.7-200.fc41"
           - "6.12.8-200.fc41"
           - "6.10.12-200.fc40"

--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -27,6 +27,10 @@ static volatile const struct xdp_dispatcher_config conf = {};
 
 /* The volatile return value prevents the compiler from assuming it knows the
  * return value and optimising based on that.
+ *
+ * The function includes a no-op xdp_adjust_tail() call before returning, to
+ * make sure the verifier doesn't disallow freplace with programs that
+ * invalidate the packet data pointer.
  */
 forloop(`i', `0', NUM_PROGS,
 `__attribute__ ((noinline))
@@ -35,6 +39,8 @@ int format(`prog%d', i)(struct xdp_md *ctx) {
 
         if (!ctx)
           return XDP_ABORTED;
+
+        bpf_xdp_adjust_tail(ctx, 0);
         return ret;
 }
 ')

--- a/lib/testing/Makefile
+++ b/lib/testing/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
 TEST_TARGETS := test-tool
-XDP_TARGETS := test_long_func_name xdp_drop xdp_pass
+XDP_TARGETS := test_long_func_name xdp_drop xdp_pass xdp_adjust_tail
 SCRIPTS_FILES := test_runner.sh setup-netns-env.sh run_tests.sh
 XDP_OBJ_INSTALL :=
 

--- a/lib/testing/xdp_adjust_tail.c
+++ b/lib/testing/xdp_adjust_tail.c
@@ -1,0 +1,12 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("xdp")
+int xdp_adjust_tail(struct xdp_md *ctx)
+{
+	if (bpf_xdp_adjust_tail(ctx, -1) < 0)
+		return XDP_ABORTED;
+	return XDP_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/xdp-loader/tests/test-xdp-loader.sh
+++ b/xdp-loader/tests/test-xdp-loader.sh
@@ -1,5 +1,5 @@
 XDP_LOADER=${XDP_LOADER:-./xdp-loader}
-ALL_TESTS="test_load test_section test_prog_name test_load_multi test_load_incremental test_load_clobber test_features"
+ALL_TESTS="test_load test_section test_prog_name test_load_adjust_tail test_load_multi test_load_incremental test_load_clobber test_features"
 
 test_load()
 {
@@ -17,6 +17,19 @@ test_prog_name()
 {
 	check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_drop.o -n xdp_drop -vv
 	check_run $XDP_LOADER unload $NS --all -vv
+}
+
+test_load_adjust_tail()
+{
+    check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_adjust_tail.o -vv
+
+    # Need to load twice to test freplace of both the top-level dispatcher
+    # function as well as sub-functions for multi-prog; but only do this if we
+    # the kernel actually supports loading multiple programs
+    if is_multiprog_supported; then
+        check_run $XDP_LOADER load $NS $TEST_PROG_DIR/xdp_adjust_tail.o -vv
+    fi
+    check_run $XDP_LOADER unload $NS --all -vv
 }
 
 check_progs_loaded()


### PR DESCRIPTION
Newer kernels added checks that disallow replacing functions that don't modify
the packet pointer with ones that do. For libxdp this means that programs that
modify the packet pointer refuses to load. Fix this by adding the recommended
workaround to the dispatcher program.

Fixes #503