### PR TITLE
test_runner: skip cleanup proc dir in teardown if no STATEDIR

### DIFF
--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -373,14 +373,16 @@ teardown()
         teardown_ns $ns
     done
 
-    for f in ${STATEDIR}/proc/*; do
-        if [ -f "$f" ]; then
-            local pid="${f/${STATEDIR}\/proc\//}"
-            stop_background "$pid" &> /dev/null || true
-        fi
-    done
+    if ! [ -z ${STATEDIR} ]; then
+        for f in ${STATEDIR}/proc/*; do
+            if [ -f "$f" ]; then
+                local pid="${f/${STATEDIR}\/proc\//}"
+                stop_background "$pid" &> /dev/null || true
+            fi
+        done
 
-    rm -rf "$STATEDIR"
+        rm -rf "$STATEDIR"
+    fi
 }
 
 ns_exec()


### PR DESCRIPTION
teardown() tries to cleanup /proc dir and cannot exit normally when misses required tool.

Without this patch:
```
# time /usr/share/xdp-tools/run_tests.sh
Running all tests from /usr/share/xdp-tools/tests
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
^C

real	0m54.757s
user	0m2.434s
sys	0m49.946s
```
With this patch:
```
# time /usr/share/xdp-tools/run_tests.sh
Running all tests from /usr/share/xdp-tools/tests
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat
    Executing tests in separate net- and mount namespaces
Missing required tool: socat

real	0m0.108s
user	0m0.053s
sys	0m0.046s

```