### PR TITLE
xdp-trafficgen: fix probe_options missing END_OPTIONS

### DIFF
--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -1031,6 +1031,7 @@ static struct prog_option probe_options[] = {
 		      .metavar = "<ifname>",
 		      .short_opt = 'i',
 		      .help = "Probe features of device <ifname>"),
+	END_OPTIONS
 };
 
 int do_probe(const void *opt, __unused const char *pin_root_path)


### PR DESCRIPTION
Probe does not work w/o "-i" option.
Fix the error by adding END_OPTIONS to probe_options.

$ sudo xdp-trafficgen probe -i ens5
Missing required option '--interface'

Usage: xdp-trafficgen [options] <hostname>
Use --help (or -h) to see full option list.