### PR TITLE
Improve selftest execution time

### DIFF
--- a/.github/scripts/prepare_test_tools.sh
+++ b/.github/scripts/prepare_test_tools.sh
@@ -6,9 +6,3 @@ set -e
 echo ::group::Install xdp-test-harness
 sudo python3 -m pip install xdp_test_harness
 echo ::endgroup::
-
-
-echo ::group::Install virtme
-git clone https://github.com/amluto/virtme
-sudo python3 -m pip install ./virtme
-echo ::endgroup::

--- a/.github/scripts/run_tests_in_vm.sh
+++ b/.github/scripts/run_tests_in_vm.sh
@@ -11,7 +11,7 @@ done
 touch TEST_OUTPUT
 tail -f TEST_OUTPUT &
 
-sudo virtme-run --kdir kernel --script-exec .github/scripts/run_tests.sh --pwd --rw --mods=auto --qemu-opts -cpu qemu64 -machine accel=tcg -m 2G
+sudo virtme-ng --run kernel --exec .github/scripts/run_tests.sh --rw --memory 2G
 
 kill %1
 

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   selftest:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         KERNEL_VERSION:
@@ -47,18 +47,13 @@ jobs:
       - name: Prepare packages
         run: |
           sudo apt-get update
-          sudo apt-get install zstd binutils-dev elfutils libpcap-dev libelf-dev gcc-multilib pkg-config wireshark tshark bpfcc-tools python3 python3-pip python3-setuptools qemu-kvm rpm2cpio libdw-dev libdwarf-dev libcap-ng-dev socat
+          sudo apt-get install zstd binutils-dev elfutils libpcap-dev libelf-dev libbpf-dev linux-tools-common gcc-multilib pkg-config wireshark tshark bpfcc-tools python3 python3-pip python3-setuptools qemu-kvm rpm2cpio libdw-dev libdwarf-dev libcap-ng-dev socat virtme-ng
       - name: Prepare Clang
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get -qq update
           sudo apt-get -qq -y install clang-$LLVM_VERSION lld-$LLVM_VERSION llvm-$LLVM_VERSION
-      - name: Install latest bpftool
-        run: |
-          git clone --depth=1 --recurse-submodules https://github.com/libbpf/bpftool bpftool
-          make -C bpftool/src
-          sudo make install -C bpftool/src prefix=/usr
       - name: Compile
         run: make
       - name: Prepare test tools

--- a/lib/libxdp/Makefile
+++ b/lib/libxdp/Makefile
@@ -39,7 +39,7 @@ VERSION_SCRIPT := libxdp.map
 CHECK_RULES := check_abi
 endif
 
-all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check man
+all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check man build_tests
 
 clean:
 	$(Q)rm -f $(STATIC_LIBS) $(STATIC_OBJS) $(SHARED_LIBS) $(SHARED_OBJS) $(XDP_OBJS) $(PC_FILE) $(MAN_OBJ) $(TEMPLATED_SOURCES) *.ll
@@ -152,6 +152,10 @@ $(MAN_PAGE): $(MAN_OBJ) $(LIBMK)
 		sed -e "1 s/DATE/$$DATE/" -e "1 s/VERSION/v$(TOOLS_VERSION)/" -e '1,5 s/^.SH "\([^"]\+\) - \([^"]\+\)"/.SH "NAME"\n\1 \\- \2\n.SH "SYNOPSIS"/' $< > $@
 
 endif
+
+.PHONY: build_tests
+build_tests: $(SHARED_LIBS) $(STATIC_LIBS)
+	$(Q)$(MAKE) -C $(TEST_DIR)
 
 .PHONY: test
 test: all

--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -3251,16 +3251,16 @@ static int xdp_detach_link(__u32 ifindex, __u32 prog_id) {
 		err = bpf_obj_get_info_by_fd(fd, &link_info, &link_info_len);
 		if (err) {
 			err = -errno;
-			pr_debug("Can't get link info for %u: %s", id, strerror(errno));
+			pr_debug("Can't get link info for %u: %s\n", id, strerror(errno));
 			break;
 		}
 
 		if (link_info.type == BPF_LINK_TYPE_XDP && link_info.xdp.ifindex == ifindex && link_info.prog_id == prog_id) {
-			pr_debug("Detach link for id %u for prog %u on interface %u", id, prog_id, ifindex);
+			pr_debug("Detach link for id %u for prog %u on interface %u\n", id, prog_id, ifindex);
 			err = bpf_link_detach(fd);
 			if (err) {
 				err = -errno;
-				pr_warn("Can't detach link %u: %s", id, strerror(errno));
+				pr_warn("Can't detach link %u: %s\n", id, strerror(errno));
 			}
 			break;
 		}

--- a/lib/libxdp/tests/test_runner.sh
+++ b/lib/libxdp/tests/test_runner.sh
@@ -50,25 +50,37 @@ exec_test()
     local testn="$1"
     local output
     local ret
+    local prefix
 
-    printf "     %-30s" "[$testn]"
+    prefix=$(printf "     %-30s" "[$testn]")
     if ! is_func "$testn"; then
-        echo "INVALID"
+        echo "${prefix}INVALID"
         return 1
     fi
 
-    output=$($testn 2>&1)
-    ret=$?
+    if [ "$VERBOSE_TESTS" -eq "1" ]; then
+        echo "${prefix}START:"
+        ($testn 2>&1) | sed -u 's/^/          /'
+        ret=${PIPESTATUS[0]}
+        echo "          Test $testn exited with return code: $ret"
+    else
+        echo -n "$prefix"
+        output=$($testn 2>&1)
+        ret=$?
+        prefix=
+    fi
+
     if [ "$ret" -eq "0" ]; then
-        echo "PASS"
+        echo "${prefix}PASS"
     elif [ "$ret" -eq "$SKIPPED_TEST" ]; then
-        echo "SKIPPED"
+        echo "${prefix}SKIPPED"
         ret=0
     else
-        echo "FAIL"
+        echo "${prefix}FAIL"
     fi
-    if [ "$ret" -ne "0" ] || [ "$VERBOSE_TESTS" -eq "1" ]; then
-        echo "$output" | sed 's/^/\t/'
+    if [ "$ret" -ne "0" ] && [ "$VERBOSE_TESTS" -ne "1" ]; then
+        echo "$output" | sed  's/^/          /'
+        echo "          Test $testn exited with return code: $ret"
     fi
     return $ret
 }

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -312,6 +312,9 @@ init_ns()
     ethtool -K "$nsname" rxvlan off txvlan off gro on
     ethtool -K "$peername" rxvlan off txvlan off gro on
 
+    ip link set dev "$peername" arp off multicast off
+    ip link set dev "$nsname" arp off multicast off
+
     ip link set dev "$peername" netns "$nsname"
     ip link set dev "$nsname" up
     ip addr add dev "$nsname" "${OUTSIDE_IP6}/${IP6_PREFIX_SIZE}"

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -204,15 +204,27 @@ start_background_ns_devnull()
     echo $PID
 }
 
+kill_process_group()
+{
+    local PID=$1
+
+    kill -SIGINT -$PID
+    for i in $(seq 10); do
+        ps --ppid $PID -p $PID > /dev/null || return 0
+        sleep 0.1
+    done
+    kill -TERM -$PID
+}
+
 stop_background()
 {
     local PID=$1
 
     local OUTPUT_FILE="${STATEDIR}/proc/${PID}"
-    if kill -SIGINT "-$PID" 2>/dev/null; then
-       sleep 2 # Wait to make sure the buffer is flushed after the shutdown
-       kill -SIGTERM "-$PID" 2>/dev/null && sleep 1 # just in case SIGINT was not enough
-    fi
+    local pids
+
+    kill_process_group $PID
+
 
     if [ -f "$OUTPUT_FILE" ]; then
         cat "$OUTPUT_FILE"

--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -411,24 +411,35 @@ exec_test()
     local testn="$1"
     local output
     local ret
+    local prefix
 
-    printf "     %-30s" "[$testn]"
+    prefix=$(printf "     %-30s" "[$testn]")
     if ! is_func "$testn"; then
-        echo "INVALID"
+        echo "${prefix}INVALID"
         return 1
     fi
 
-    output=$($testn 2>&1)
-    ret=$?
+    if [ "$VERBOSE_TESTS" -eq "1" ]; then
+        echo "${prefix}START:"
+        ($testn 2>&1) | sed  's/^/          /'
+        ret=${PIPESTATUS[0]}
+        echo "          Test $testn exited with return code: $ret"
+    else
+        echo -n "$prefix"
+        output=$($testn 2>&1)
+        ret=$?
+        prefix=
+    fi
+
     if [ "$ret" -eq "0" ]; then
-        echo "PASS"
+        echo "${prefix}PASS"
     elif [ "$ret" -eq "$SKIPPED_TEST" ]; then
-        echo "SKIPPED"
+        echo "${prefix}SKIPPED"
         ret=0
     else
-        echo "FAIL"
+        echo "${prefix}FAIL"
     fi
-    if [ "$ret" -ne "0" ] || [ "$VERBOSE_TESTS" -eq "1" ]; then
+    if [ "$ret" -ne "0" ] && [ "$VERBOSE_TESTS" -ne "1" ]; then
         echo "$output" | sed  's/^/          /'
         echo "          Test $testn exited with return code: $ret"
     fi

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -7,6 +7,7 @@ ALL_TESTS="test_help test_interfaces test_capt_pcap test_capt_pcapng test_capt_t
 
 XDPDUMP=${XDPDUMP:-./xdpdump}
 XDP_LOADER=${XDP_LOADER:-../xdp-loader/xdp-loader}
+TEST_RETRIES=3
 
 RESULT=""
 

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -51,7 +51,7 @@ Options:
 END
           )
 
-    $XDPDUMP --help | grep -q "\-\-perf-wakeup"
+    $XDPDUMP --help | grep -q -- "--perf-wakeup"
     if [ $? -eq 1 ]; then
         XDPDUMP_HELP_TEXT=$(echo "$XDPDUMP_HELP_TEXT" | sed '/--perf-wakeup <events>/d')
     fi

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -562,10 +562,10 @@ test_pname_parse()
 
     PID=$(start_background "$XDPDUMP -D")
     RESULT=$(stop_background "$PID")
-    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 1p | tr -d ' ')
-    PROG_ID_2=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 2p | tr -d ' ')
-    PROG_ID_3=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 3p | tr -d ' ')
-    PROG_ID_4=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 4p | tr -d ' ')
+    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 1p | tr -d ' ')
+    PROG_ID_2=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 2p | tr -d ' ')
+    PROG_ID_3=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 3p | tr -d ' ')
+    PROG_ID_4=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 4p | tr -d ' ')
 
     PID=$(start_background "$XDPDUMP -i $NS -p all")
     RESULT=$(stop_background "$PID")
@@ -614,9 +614,9 @@ test_pname_parse()
 
     PID=$(start_background "$XDPDUMP -D")
     RESULT=$(stop_background "$PID")
-    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A2 | cut -c51-55 | sed -n 1p | tr -d ' ')
-    PROG_ID_2=$(echo "$RESULT" | grep "$NS" -A2 | cut -c51-55 | sed -n 2p | tr -d ' ')
-    PROG_ID_3=$(echo "$RESULT" | grep "$NS" -A2 | cut -c51-55 | sed -n 2p | tr -d ' ')
+    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A2 | awk '{print $4}' | sed -n 1p | tr -d ' ')
+    PROG_ID_2=$(echo "$RESULT" | grep "$NS" -A2 | awk '{print $4}' | sed -n 2p | tr -d ' ')
+    PROG_ID_3=$(echo "$RESULT" | grep "$NS" -A2 | awk '{print $4}' | sed -n 2p | tr -d ' ')
 
     PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name")
     RESULT=$(stop_background "$PID")
@@ -645,8 +645,8 @@ test_multi_prog()
 
     PID=$(start_background "$XDPDUMP -D")
     RESULT=$(stop_background "$PID")
-    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 1p | tr -d ' ')
-    PROG_ID_4=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 4p | tr -d ' ')
+    PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 1p | tr -d ' ')
+    PROG_ID_4=$(echo "$RESULT" | grep "$NS" -A4 | awk '{print $4}' | sed -n 4p | tr -d ' ')
 
     PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 -vv")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1

--- a/xdp-dump/tests/test-xdpdump.sh
+++ b/xdp-dump/tests/test-xdpdump.sh
@@ -110,9 +110,8 @@ test_capt_pcap()
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --use-pcap -w - 2> /dev/null | tcpdump -r - -n")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --use-pcap -w - | tcpdump -r - -n")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
-    sleep 1
     RESULT=$(stop_background "$PID")
 
     $XDP_LOADER unload "$NS" --all || return 1
@@ -166,7 +165,7 @@ test_capt_pcapng()
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -w - 2> /dev/null | tcpdump -r - -n")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -w - | tcpdump -r - -n")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
 
@@ -175,7 +174,7 @@ test_capt_pcapng()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -w $PCAP_FILE --rx-capture=entry,exit")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -w $PCAP_FILE --rx-capture=entry,exit")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || (rm "$PCAP_FILE" >& /dev/null; return 1)
     RESULT=$(stop_background "$PID") || (print_result "xdpdump failed"; rm "$PCAP_FILE" >& /dev/null; return 1)
 
@@ -219,7 +218,7 @@ test_capt_term()
 
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
 
@@ -228,7 +227,7 @@ test_capt_term()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
 
@@ -261,7 +260,7 @@ test_exitentry()
 
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=entry")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=entry")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_ENTRY_REGEX ]]; then
@@ -269,7 +268,7 @@ test_exitentry()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=exit")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=exit")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_EXIT_REGEX ]]; then
@@ -280,16 +279,16 @@ test_exitentry()
     $XDP_LOADER unload "$NS" --all || return 1
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/xdp_drop.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS --rx-capture=exit")
-    $PING6 -W 1 -c 1 "$INSIDE_IP6" # Note that this ping will fail!!
+    PID=$(start_tcpdump "$XDPDUMP -i $NS --rx-capture=exit")
+    $PING6 -W 0.1 -c 1 "$INSIDE_IP6" # Note that this ping will fail!!
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_EXIT_D_REGEX ]]; then
         print_result "IPv6 drop exit packet not received"
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS --rx-capture=exit,entry")
-    $PING6 -W 1 -c 1 "$INSIDE_IP6" # Note that this ping will fail!!
+    PID=$(start_tcpdump "$XDPDUMP -i $NS --rx-capture=exit,entry")
+    $PING6 -W 0.1 -c 1 "$INSIDE_IP6" # Note that this ping will fail!!
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_EXIT_D_REGEX && $RESULT =~ $PASS_ENTRY_D_REGEX ]]; then
         print_result "IPv6 drop entry/exit packet not received"
@@ -318,7 +317,7 @@ test_snap()
 
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x --snapshot-length=16")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x --snapshot-length=16")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
 
@@ -327,7 +326,7 @@ test_snap()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x -s 21")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x -s 21")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
 
@@ -352,8 +351,8 @@ test_multi_pkt()
 
     for PKT_SIZE in "${PKT_SIZES[@]}" ; do
 
-        PID=$(start_background_no_stderr "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=entry,exit")
-        timeout 40 $PING6 -q -W 2 -s "$PKT_SIZE" -c 20000 -f "$INSIDE_IP6" || return 1
+        PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --rx-capture=entry,exit")
+        timeout 40 $PING6 -q -W 0.1 -s "$PKT_SIZE" -c 20000 -f "$INSIDE_IP6" || return 1
         RESULT=$(stop_background "$PID")
         if ! [[ $RESULT =~ $PASS_ENTRY_REGEX ]]; then
             print_result "IPv6 entry packet not received, $PKT_SIZE"
@@ -374,7 +373,7 @@ test_perf_wakeup()
     skip_if_missing_kernel_symbol bpf_xdp_output_proto
     skip_if_missing_trace_attach
 
-    $XDPDUMP --help | grep -q "\-\-perf-wakeup"
+    $XDPDUMP --help | grep -q -- "--perf-wakeup"
     if [ $? -eq 1 ]; then
         # No support for perf_wakeup, so return SKIP
         return "$SKIPPED_TEST"
@@ -389,7 +388,7 @@ test_perf_wakeup()
     for WAKEUP in "${WAKEUPS[@]}" ; do
 
         # We send a single packet to make sure flushing of the buffer works!
-        PID=$(start_background_no_stderr "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --perf-wakeup=$WAKEUP")
+        PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --perf-wakeup=$WAKEUP")
         $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
         RESULT=$(stop_background "$PID")
 
@@ -399,7 +398,7 @@ test_perf_wakeup()
         fi
 
         # We sent 10k packets and see if the all arrive
-        PID=$(start_background_no_stderr "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --perf-wakeup=$WAKEUP")
+        PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name --perf-wakeup=$WAKEUP")
         timeout 20 "$PING6" -q -W 2 -c 10000 -f  "$INSIDE_IP6" || return 1
         RESULT=$(stop_background "$PID")
         if ! [[ $RESULT =~ $PASS_10K_REGEX ]]; then
@@ -418,8 +417,9 @@ test_none_xdp()
 
     $XDP_LOADER unload "$NS" --all
 
-    PID=$(start_background "$XDPDUMP -i $NS")
-    $PING6 -W 2 -c 4 "$INSIDE_IP6" || return 1
+    PID=$(start_tcpdump "$XDPDUMP -i $NS")
+    $PING6 -i 0.1 -W 2 -c 4 "$INSIDE_IP6" || return 1
+    sleep 1
     RESULT=$(stop_background "$PID")
     if [[ "$RESULT" != *"$PASS_PKT"* ]]; then
         print_result "IPv6 packet not received"
@@ -439,8 +439,9 @@ test_promiscuous_selfload()
     $XDP_LOADER unload "$NS" --all
     dmesg -C
 
-    PID=$(start_background "$XDPDUMP -i $NS -P")
-    $PING6 -W 2 -c 4 "$INSIDE_IP6" || return 1
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -P")
+    $PING6 -i 0.1 -W 2 -c 4 "$INSIDE_IP6" || return 1
+    sleep 1
     RESULT=$(stop_background "$PID")
     if [[ "$RESULT" != *"$PASS_PKT"* ]]; then
         print_result "IPv6 packet not received [legacy mode]"
@@ -468,7 +469,7 @@ test_promiscuous_preload()
     $XDP_LOADER load "$NS" "$TEST_PROG_DIR/test_long_func_name.o" || return 1
     dmesg -C
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x --promiscuous-mode")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name -x --promiscuous-mode")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_REGEX ]]; then
@@ -513,7 +514,7 @@ test_pname_parse()
     fi
 
     # Here we specify the correct function name so we should get the packet
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_test_prog_with_a_long_name")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $PASS_REGEX ]]; then
@@ -647,7 +648,7 @@ test_multi_prog()
     PROG_ID_1=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 1p | tr -d ' ')
     PROG_ID_4=$(echo "$RESULT" | grep "$NS" -A4 | cut -c51-55 | sed -n 4p | tr -d ' ')
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 -vv")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 -vv")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if [[ $RESULT == *"Unrecognized arg#0 type PTR"* ]]; then
@@ -659,7 +660,7 @@ test_multi_prog()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 --rx-capture=exit")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 --rx-capture=exit")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $EXIT_REGEX ]]; then
@@ -667,7 +668,7 @@ test_multi_prog()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 --rx-capture=exit,entry")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_dispatcher,xdp_pass@$PROG_ID_4 --rx-capture=exit,entry")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $ENTRY_REGEX ]]; then
@@ -679,7 +680,7 @@ test_multi_prog()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p $PROG_ID_1,$PROG_ID_4 --rx-capture=exit,entry")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p $PROG_ID_1,$PROG_ID_4 --rx-capture=exit,entry")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $ENTRY_REGEX ]]; then
@@ -691,7 +692,7 @@ test_multi_prog()
         return 1
     fi
 
-    PID=$(start_background "$XDPDUMP -i $NS -p xdp_dispatcher,$PROG_ID_4 --rx-capture=exit,entry")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS -p xdp_dispatcher,$PROG_ID_4 --rx-capture=exit,entry")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if ! [[ $RESULT =~ $ENTRY_REGEX ]]; then
@@ -712,7 +713,7 @@ test_xdp_load()
     local PASS_REGEX="(xdpdump\(\)@entry: packet size 118 bytes on if_index [0-9]+, rx queue [0-9]+, id [0-9]+)"
     local WARN_MSG="Will load a capture only XDP program!"
 
-    PID=$(start_background "$XDPDUMP -i $NS --load-xdp-program")
+    PID=$(start_tcpdump "$XDPDUMP -i $NS --load-xdp-program")
     $PING6 -W 2 -c 1 "$INSIDE_IP6" || return 1
     RESULT=$(stop_background "$PID")
     if [[ "$RESULT" != *"$WARN_MSG"* ]]; then

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -670,6 +670,7 @@ static bool capture_on_legacy_interface(struct dumpopt *cfg)
 	}
 	exit_pcap = NULL;
 	rc = true;
+	fflush(stdout);
 
 	fprintf(stderr, "\n%"PRIu64" packets captured\n", captured_packets);
 	if (pcap_stats(pcap, &ps) == 0) {
@@ -1859,6 +1860,7 @@ static bool capture_on_interface(struct dumpopt *cfg)
 	perf_buffer__consume(perf_buf);
 #endif
 
+	fflush(stdout);
 	fprintf(stderr, "\n%"PRIu64" packets captured\n",
 		perf_ctx.captured_packets);
 	fprintf(stderr, "%"PRIu64" packets dropped by perf ring\n",

--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -1768,19 +1768,6 @@ static bool capture_on_interface(struct dumpopt *cfg)
 		}
 	}
 
-	/* No more error conditions, display some capture information */
-	fprintf(stderr, "listening on %s, ingress XDP program ",
-		cfg->iface.ifname);
-
-	for (unsigned int i = 0; i < tgt_progs.nr_of_progs; i++)
-		fprintf(stderr, "ID %u func %s, ",
-			xdp_program__id(tgt_progs.progs[i].prog),
-			tgt_progs.progs[i].func);
-
-	fprintf(stderr, "capture mode %s, capture size %d bytes\n",
-		get_capture_mode_string(tgt_progs.progs[0].rx_capture),
-		cfg->snaplen);
-
 	/* Setup perf context */
 	memset(&perf_ctx, 0, sizeof(perf_ctx));
 	perf_ctx.cfg = cfg;
@@ -1846,6 +1833,20 @@ static bool capture_on_interface(struct dumpopt *cfg)
 			strerror(errno), errno);
 		goto error_exit;
 	}
+
+	/* No more error conditions, display some capture information */
+	fprintf(stderr, "listening on %s, ingress XDP program ",
+		cfg->iface.ifname);
+
+	for (unsigned int i = 0; i < tgt_progs.nr_of_progs; i++)
+		fprintf(stderr, "ID %u func %s, ",
+			xdp_program__id(tgt_progs.progs[i].prog),
+			tgt_progs.progs[i].func);
+
+	fprintf(stderr, "capture mode %s, capture size %d bytes\n",
+		get_capture_mode_string(tgt_progs.progs[0].rx_capture),
+		cfg->snaplen);
+	fflush(stderr);
 
 	/* Loop trough the dumper */
 	while (!exit_xdpdump) {

--- a/xdp-filter/tests/test-xdp-filter.sh
+++ b/xdp-filter/tests/test-xdp-filter.sh
@@ -59,10 +59,9 @@ check_packet()
     local command="$2"
     local expect="$3"
     echo "Checking command '$command' filter '$filter'"
-    PID=$(start_background tcpdump --immediate-mode -epni $NS "$filter")
+    PID=$(start_tcpdump tcpdump --immediate-mode -epni $NS "$filter")
     echo "Started listener as $PID"
     ns_exec bash -c "$command"
-    sleep 1
     output=$(stop_background $PID)
     echo "$output"
 
@@ -87,7 +86,7 @@ check_port()
     local port=$2
     local expect=$3
     echo "$type port $port $expect"
-    [[ "$type" == "tcp" ]] && command="echo test | socat - TCP6:[$OUTSIDE_IP6]:$port,connect-timeout=1"
+    [[ "$type" == "tcp" ]] && command="echo test | socat - TCP6:[$OUTSIDE_IP6]:$port,connect-timeout=0.1"
     [[ "$type" == "udp" ]] && command="echo test | socat - UDP6:[$OUTSIDE_IP6]:$port"
 
     check_packet "$type dst port $port" "$command" $expect
@@ -132,7 +131,7 @@ test_ports_deny()
 
 check_ping6()
 {
-    check_packet "dst $OUTSIDE_IP6" "$PING6 -c 1 $OUTSIDE_IP6" $1
+    check_packet "dst $OUTSIDE_IP6" "$PING6 -W 0.1 -c 1 $OUTSIDE_IP6" $1
 }
 
 test_ipv6_allow()
@@ -167,7 +166,7 @@ test_ipv6_deny()
 
 check_ping4()
 {
-    check_packet "dst $OUTSIDE_IP4" "ping -c 1 $OUTSIDE_IP4" $1
+    check_packet "dst $OUTSIDE_IP4" "ping -W 0.1 -c 1 $OUTSIDE_IP4" $1
 }
 
 test_ipv4_allow()

--- a/xdp-forward/tests/test-xdp-forward.sh
+++ b/xdp-forward/tests/test-xdp-forward.sh
@@ -122,17 +122,14 @@ table inet filter {
     }
 }
 EOF
-    # wait a bit to configure nft
-    sleep 2
-
     check_run $XDP_FORWARD load -f flowtable ${NS_NAMES[@]}
 
-    PID=$(start_background_ns_devnull "socat -4 TCP-LISTEN:10000,reuseaddr,fork -")
-    check_run ip netns exec ${NS_NAMES[0]} socat ${INPUT_FILE} TCP4:${OUTSIDE_IP4}:12345,connect-timeout=1
+    PID=$(start_socat_ns "socat -dd -4 TCP-LISTEN:10000,reuseaddr,fork -")
+    check_run ip netns exec ${NS_NAMES[0]} socat ${INPUT_FILE} TCP4:${OUTSIDE_IP4}:12345,connect-timeout=0.2
     stop_background $PID
 
-    PID=$(start_background_ns_devnull "socat -6 TCP-LISTEN:10000,reuseaddr,fork -")
-    check_run ip netns exec ${NS_NAMES[0]} socat ${INPUT_FILE} TCP6:[${OUTSIDE_IP6}]:12345,connect-timeout=1
+    PID=$(start_socat_ns "socat -dd -6 TCP-LISTEN:10000,reuseaddr,fork -")
+    check_run ip netns exec ${NS_NAMES[0]} socat ${INPUT_FILE} TCP6:[${OUTSIDE_IP6}]:12345,connect-timeout=0.2
     stop_background $PID
 
     check_run $XDP_FORWARD unload ${NS_NAMES[@]}


### PR DESCRIPTION
This series makes a bunch of improvements to the test runners to make the tests
run faster. This consists of removing a bunch of sleep-based waits in favour of
explicit waits on particular output for the background processes.

Together, these changes reduce the time of a full 'make test' run from about
nine minutes, to just under one minute on my machine.