### PR TITLE
test_runner: Wait for background output file to appear before moving it

### DIFF
--- a/lib/testing/test_runner.sh
+++ b/lib/testing/test_runner.sh
@@ -169,13 +169,28 @@ die()
     exit 1
 }
 
+mv_tmpfile()
+{
+    local src="$1"
+    local dst="$2"
+    local MAXWAIT=100
+
+    while ! [ -f "$src" ]; do
+        sleep 0.1
+        MAXWAIT=$[$MAXWAIT - 1]
+        [ "$MAXWAIT" -eq 0 ] && break
+    done
+
+    mv "$src" "$dst"
+}
+
 start_background()
 {
     local TMP_FILE="${STATEDIR}/tmp_proc_$$_$RANDOM"
     setsid bash -c "$*" &> ${TMP_FILE} &
     local PID=$!
 
-    mv "$TMP_FILE" "${STATEDIR}/proc/${PID}" >& /dev/null
+    mv_tmpfile "$TMP_FILE" "${STATEDIR}/proc/${PID}"
 
     echo "$PID"
 }
@@ -213,7 +228,7 @@ start_background_no_stderr()
     setsid bash -c "$*" 1> ${TMP_FILE} 2>/dev/null &
     local PID=$!
 
-    mv "$TMP_FILE" "${STATEDIR}/proc/${PID}" >& /dev/null
+    mv_tmpfile "$TMP_FILE" "${STATEDIR}/proc/${PID}"
 
     echo "$PID"
 }
@@ -224,7 +239,7 @@ start_background_ns_devnull()
     setsid ip netns exec "$NS" env TESTENV_NAME="$NS" "$SETUP_SCRIPT" bash -c "$*" 1>/dev/null 2>${TMP_FILE} &
     local PID=$!
 
-    mv "$TMP_FILE" "${STATEDIR}/proc/${PID}" >& /dev/null
+    mv_tmpfile "$TMP_FILE" "${STATEDIR}/proc/${PID}"
     echo $PID
 }
 


### PR DESCRIPTION
On slow test execution systems (vm-in-vm setups), spawning a background
process can take so long that the output file is not created before the
test script tries to move it into place. This in turns leads to lost
output and subsequent test failures.

Fix this by waiting on the temporary file to appear before moving it.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>