### PR TITLE
configure: support compilation for non-sudoers

### DIFF
--- a/configure
+++ b/configure
@@ -109,11 +109,15 @@ check_toolchain()
         exit 1
     fi
 
+    if ! command -v $BPFTOOL &>/dev/null; then
+        BPFTOOL=$(whereis -b bpftool | awk '{print $2}')
+    fi
+
     if command -v $BPFTOOL &>/dev/null && $BPFTOOL gen help 2>&1 | grep 'gen skeleton.*name' > /dev/null; then
         bpftool_version=$($BPFTOOL version | head -n 1)
-	echo "using $bpftool_version"
+        echo "using $bpftool_version"
     else
-	echo "bpftool not found or doesn't support skeleton generation; not building all tools"
+        echo "bpftool not found or doesn't support skeleton generation; not building all tools"
         BPFTOOL=
     fi
 


### PR DESCRIPTION
In debian 12, `bpftool` path is /usr/sbin/bpftool, `bpftool` can not be found and executed for non-sudoers.