### PR TITLE
Xdp bench redir map action drop

### DIFF
--- a/xdp-bench/README.org
+++ b/xdp-bench/README.org
@@ -457,6 +457,7 @@ Set egress program to load:
 
 #+begin_src sh
  forward	- Update the packet data so its source MAC address matches the one of the destination interface.
+ drop		- Drop packet.
 #+end_src
 
 The default for this option is =forward=.
@@ -517,6 +518,7 @@ Set egress program to load:
 
 #+begin_src sh
  forward	- Update the packet data so its source MAC address matches the one of the destination interface.
+ drop		- Drop packet.
 #+end_src
 
 The default for this option is =forward=.

--- a/xdp-bench/tests/test-xdp-bench.sh
+++ b/xdp-bench/tests/test-xdp-bench.sh
@@ -112,6 +112,7 @@ test_redirect_map_egress()
     if is_progmap_supported; then
         check_run $XDP_BENCH redirect-map btest0 btest1 -X -vv
         check_run $XDP_BENCH redirect-map btest0 btest1 -X -A forward -vv
+        check_run $XDP_BENCH redirect-map btest0 btest1 -X -A drop -vv
     fi
     ip link del dev btest0
 }
@@ -140,6 +141,7 @@ test_redirect_multi_egress()
 
     check_run $XDP_BENCH redirect-multi btest0 btest1 btest2 btest3 -X -vv
     check_run $XDP_BENCH redirect-multi btest0 btest1 btest2 btest3 -X -A forward -vv
+    check_run $XDP_BENCH redirect-multi btest0 btest1 btest2 btest3 -X -A drop -vv
 
     ip link del dev btest0
     ip link del dev btest2

--- a/xdp-bench/xdp-bench.8
+++ b/xdp-bench/xdp-bench.8
@@ -1,4 +1,4 @@
-.TH "xdp-bench" "8" "NOVEMBER 19, 2024" "V1.5.8" "A simple XDP benchmarking tool"
+.TH "xdp-bench" "8" "DECEMBER 14, 2025" "V1.5.8" "A simple XDP benchmarking tool"
 .SH "NAME"
 XDP-bench \- a simple XDP benchmarking tool
 .SH "SYNOPSIS"
@@ -522,6 +522,7 @@ Set egress program to load:
 .RS
 .nf
 \fCforward	- Update the packet data so its source MAC address matches the one of the destination interface.
+drop		- Drop packet.
 \fP
 .fi
 .RE
@@ -590,6 +591,7 @@ Set egress program to load:
 .RS
 .nf
 \fCforward	- Update the packet data so its source MAC address matches the one of the destination interface.
+drop		- Drop packet.
 \fP
 .fi
 .RE

--- a/xdp-bench/xdp-bench.c
+++ b/xdp-bench/xdp-bench.c
@@ -70,6 +70,7 @@ struct enum_val cpumap_program_modes[] = {
 
 struct enum_val devmap_egress_actions[] = {
        {"forward", DEVMAP_EGRESS_FORWARD },
+       {"drop", DEVMAP_EGRESS_DROP },
        {NULL, 0}
 };
 

--- a/xdp-bench/xdp-bench.h
+++ b/xdp-bench/xdp-bench.h
@@ -51,6 +51,7 @@ struct redirect_opts {
 enum devmap_egress_action {
 	DEVMAP_EGRESS_NONE,
 	DEVMAP_EGRESS_FORWARD,
+	DEVMAP_EGRESS_DROP,
 };
 
 struct devmap_opts {

--- a/xdp-bench/xdp_redirect_devmap.bpf.c
+++ b/xdp-bench/xdp_redirect_devmap.bpf.c
@@ -85,4 +85,10 @@ int xdp_redirect_devmap_egress(struct xdp_md *ctx)
 	return XDP_PASS;
 }
 
+SEC("xdp/devmap")
+int xdp_redirect_devmap_egress_drop(struct xdp_md *ctx)
+{
+	return XDP_DROP;
+}
+
 char _license[] SEC("license") = "GPL";

--- a/xdp-bench/xdp_redirect_devmap.c
+++ b/xdp-bench/xdp_redirect_devmap.c
@@ -37,6 +37,8 @@ static struct bpf_program *egress_prog(struct xdp_redirect_devmap *skel,
 				       enum devmap_egress_action action)
 {
 	switch (action) {
+	case DEVMAP_EGRESS_DROP:
+		return skel->progs.xdp_redirect_devmap_egress_drop;
 	case DEVMAP_EGRESS_NONE:
 	case DEVMAP_EGRESS_FORWARD:
 	default:

--- a/xdp-bench/xdp_redirect_devmap_multi.bpf.c
+++ b/xdp-bench/xdp_redirect_devmap_multi.bpf.c
@@ -74,4 +74,10 @@ int xdp_devmap_prog(struct xdp_md *ctx)
 	return XDP_PASS;
 }
 
+SEC("xdp/devmap")
+int xdp_redirect_devmap_egress_drop(struct xdp_md *ctx)
+{
+	return XDP_DROP;
+}
+
 char _license[] SEC("license") = "GPL";

--- a/xdp-bench/xdp_redirect_devmap_multi.c
+++ b/xdp-bench/xdp_redirect_devmap_multi.c
@@ -72,6 +72,8 @@ egress_prog_multi(struct xdp_redirect_devmap_multi *skel,
 		  enum devmap_egress_action action)
 {
 	switch (action) {
+	case DEVMAP_EGRESS_DROP:
+		return skel->progs.xdp_redirect_devmap_egress_drop;
 	case DEVMAP_EGRESS_NONE:
 	case DEVMAP_EGRESS_FORWARD:
 	default:


### PR DESCRIPTION
As [requested by Jesper](https://lore.kernel.org/all/58b50903-7969-46bd-bd73-60629c00f057@kernel.org/), added a egress mode for xdp-bench in `redirect-map` and `redirect-multimap` modes. This action can be `forward` (as before) or `drop` (new).

Haven't found any guidelines for contribution so please excuse me if I omitted something.
