### PR TITLE
.github/workflows: Switch to maintained release creation action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
         run: |
           ./mkarchive.sh
 
-      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" #v1.2.1
+      - uses: "softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b" # v2.5.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
+          generate_release_notes: true
+          make_latest: true
           files: |
             *.tar.gz


### PR DESCRIPTION
The action we were using to generate releases was unmaintained, so
switch to one that is actively maintained.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>