### PR TITLE
xdp-forward/xdp_flowtable: Fix backward compatibility verifier issue

### DIFF
--- a/xdp-forward/xdp_flowtable.bpf.c
+++ b/xdp-forward/xdp_flowtable.bpf.c
@@ -493,6 +493,7 @@ static __always_inline int xdp_flowtable_flags(struct xdp_md *ctx,
 	struct flow_offload *flow;
 	struct flow_ports *ports;
 	unsigned long flags;
+	__u8 xmit_type;
 
 	if (eth + 1 > data_end)
 		return XDP_PASS;
@@ -567,10 +568,11 @@ static __always_inline int xdp_flowtable_flags(struct xdp_md *ctx,
 	if (bpf_core_read(&flags, sizeof(flags), &flow->flags))
 		return XDP_PASS;
 
-	if (tuplehash->tuple.xmit_type != FLOW_OFFLOAD_XMIT_NEIGH)
+	xmit_type = BPF_CORE_READ_BITFIELD_PROBED(tuplehash, tuple.xmit_type);
+	if (xmit_type != FLOW_OFFLOAD_XMIT_NEIGH)
 		return XDP_PASS;
 
-	dir = tuplehash->tuple.dir;
+	dir = BPF_CORE_READ_BITFIELD_PROBED(tuplehash, tuple.dir);
 	if (dir >= FLOW_OFFLOAD_DIR_MAX)
 		return XDP_PASS;
 


### PR DESCRIPTION
Starting from commit 'ab427db17885 ("netfilter: flowtable: Add IPIP rx sw acceleration"), flow_offload_tuple layout has changed in order to support IP tunnel offload. Rely on bpf-core APIs to maintain backward compatibility on impacted fields.