### PR TITLE
xdpdump: include <limits.h> removed from linux/ethtool.h

### DIFF
--- a/xdp-dump/xdpdump.c
+++ b/xdp-dump/xdpdump.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
Removing include <limits.h> from linux/ethtool.h resulted in a undeclared UINT_MAX and ULONG_MAX compilation errors

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a8a11e5237aed71b7f5f9d33c554ef06fe974311

Added #include <limits.h> in xdp-dump/xdpdump.c