### PR TITLE
default CC to cc instead of gcc

### DIFF
--- a/configure
+++ b/configure
@@ -58,7 +58,7 @@ check_toolchain()
     local bpftool_version
 
     : ${PKG_CONFIG:=pkg-config}
-    : ${CC=gcc}
+    : ${CC=cc}
     : ${OBJCOPY=objcopy}
     : ${CLANG=clang}
     : ${M4=m4}


### PR DESCRIPTION
building on a system without gcc fails with error:

sh configure
*** ERROR: Cannot find tool gcc

use system default cc to enhance portability

fixes: #568