### PR TITLE
use struct ethhdr (linux) to enhance portability (clang)

### DIFF
--- a/lib/util/xdpsock.c
+++ b/lib/util/xdpsock.c
@@ -15,8 +15,6 @@
 #include <linux/udp.h>
 #include <locale.h>
 #include <arpa/inet.h>
-#include <net/ethernet.h>
-#include <netinet/ether.h>
 #include <net/if.h>
 #include <poll.h>
 #include <pthread.h>
@@ -648,14 +646,12 @@ void xsk_ctx__destroy(struct xsk_ctx *ctx)
 
 static void swap_mac_addresses(void *data)
 {
-	struct ether_header *eth = (struct ether_header *)data;
-	struct ether_addr *src_addr = (struct ether_addr *)&eth->ether_shost;
-	struct ether_addr *dst_addr = (struct ether_addr *)&eth->ether_dhost;
-	struct ether_addr tmp;
+	struct ethhdr *eth = data;
+	unsigned char tmp[ETH_ALEN];
 
-	tmp = *src_addr;
-	*src_addr = *dst_addr;
-	*dst_addr = tmp;
+	memcpy(tmp, eth->h_source, ETH_ALEN);
+	memcpy(eth->h_source, eth->h_dest, ETH_ALEN);
+	memcpy(eth->h_dest, tmp, ETH_ALEN);
 }
 
 static void hex_dump(void *pkt, size_t length, __u64 addr)

--- a/lib/util/xdpsock.h
+++ b/lib/util/xdpsock.h
@@ -8,7 +8,6 @@
 
 #include <linux/if_xdp.h>
 #include <stdbool.h>
-#include <netinet/ether.h>
 #include <time.h>
 #include <sched.h>
 #include <xdp/libxdp.h>


### PR DESCRIPTION
building with clang fails with:
/usr/include/netinet/if_ether.h:115:8: error: redefinition of 'ethhdr'

use `struct ethhdr` (linux) instead of `struct ether_header` (glibc) and
remove net/netinet-headers to avoid redefinition of `ethhdr`

fixes: #570