### PR TITLE
.github/workflows: Update actions/checkout to v6

### DIFF
--- a/.github/workflows/covscan.yml
+++ b/.github/workflows/covscan.yml
@@ -15,7 +15,7 @@ jobs:
       CLANG: clang-19
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Prepare packages


### PR DESCRIPTION
Avoids deprecation warning in test runs.

Signed-off-by: Toke Høiland-Jørgensen <toke@redhat.com>