### PR TITLE
libxdp: Return last action from multiple programs

### DIFF
--- a/lib/libxdp/xdp-dispatcher.c.in
+++ b/lib/libxdp/xdp-dispatcher.c.in
@@ -59,7 +59,7 @@ SEC("xdp")
 int xdp_dispatcher(struct xdp_md *ctx)
 {
         __u8 num_progs_enabled = conf.num_progs_enabled;
-        int ret;
+        int ret = XDP_PASS;
 forloop(`i', `0', NUM_PROGS,
 `
         if (num_progs_enabled < incr(i))
@@ -75,7 +75,7 @@ forloop(`i', `0', NUM_PROGS,
                 goto out;
         ret = compat_test(ctx);
 out:
-        return XDP_PASS;
+        return ret;
 }
 
 SEC("xdp")


### PR DESCRIPTION
When loading multiple programs which have actions set like this:

 struct {
	__uint(priority, 40);
	__uint(XDP_PASS, 0);
	__uint(XDP_REDIRECT, 1);
 } XDP_RUN_CONFIG(xdp_prog);

i.e. action other to XDP_PASS invokes next program, dispatcher will not return action from the last program, but XDP_PASS which is set at the end of the dispatcher.

Fix issue by making sure verdict from the last program is returned.