### PR TITLE
libxdp: Close refcnt_map_fd

### DIFF
--- a/lib/libxdp/tests/Makefile
+++ b/lib/libxdp/tests/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-USER_TARGETS := test_xsk_refcnt test_xdp_frags test_link_detach test_xsk_umem_flags test_xdp_devbound
+USER_TARGETS := test_xsk_refcnt test_xdp_frags test_link_detach test_xsk_umem_flags test_xdp_devbound test_xsk_map_leak
 STATIC_LINK_TARGETS := check_kern_compat test_dispatcher_versions
 BPF_TARGETS := xdp_dispatcher_v1 xdp_dispatcher_v2 xdp_pass
 USER_LIBS := -lpthread

--- a/lib/libxdp/tests/test-libxdp.sh
+++ b/lib/libxdp/tests/test-libxdp.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
-ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_devbound test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged test_link_detach test_xsk_umem_flags"
+ALL_TESTS="test_link_so test_link_a test_old_dispatcher test_xdp_devbound test_xdp_frags test_xsk_prog_refcnt_bpffs test_xsk_prog_refcnt_legacy test_xsk_non_privileged test_link_detach test_xsk_umem_flags test_xsk_map_leak"
 
 TESTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 
@@ -146,6 +146,15 @@ test_xsk_umem_flags()
 	ip link add xdp_veth0 type veth peer name xdp_veth1
 	check_run $TESTS_DIR/test_xsk_umem_flags xdp_veth0
 	ip link delete xdp_veth0
+}
+
+test_xsk_map_leak()
+{
+        check_mount_bpffs || return 1
+        NUM_QUEUES_REQUIRED=4
+        ip link add xsk_veth0 numrxqueues $NUM_QUEUES_REQUIRED type veth peer name xsk_veth1
+        check_run $TESTS_DIR/test_xsk_map_leak xsk_veth0 2>&1
+        ip link delete xsk_veth0
 }
 
 cleanup_tests()

--- a/lib/libxdp/tests/test_xsk_map_leak.c
+++ b/lib/libxdp/tests/test_xsk_map_leak.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <errno.h>
+#include <linux/err.h>
+#include <linux/membarrier.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "test_utils.h"
+
+#include <xdp/libxdp.h>
+#include <xdp/xsk.h>
+
+typedef __u64 u64;
+typedef __u32 u32;
+typedef __u16 u16;
+typedef __u8  u8;
+
+#define MAX_NUM_QUEUES 4
+
+struct xsk_umem_info {
+	struct xsk_ring_prod fq;
+	struct xsk_ring_cons cq;
+	struct xsk_umem *umem;
+	void *buffer;
+};
+
+struct xsk_socket_info {
+	struct xsk_ring_cons rx;
+	struct xsk_umem_info *umem;
+	struct xsk_socket *xsk;
+};
+
+static const char *opt_if;
+
+static struct xsk_socket_info *xsks[MAX_NUM_QUEUES];
+
+#define FRAME_SIZE 64
+#define NUM_FRAMES (XSK_RING_CONS__DEFAULT_NUM_DESCS * 2)
+
+/*
+ * Trigger synchronize_rcu() in kernel, taken from kernel's
+ * bpf selftests.
+ */
+static int kern_sync_rcu(void)
+{
+	return syscall(__NR_membarrier, MEMBARRIER_CMD_SHARED, 0, 0);
+}
+
+static int count_bpf_maps(bool list_maps)
+{
+	u32 id = 0;
+	u32 next_id = 0;
+	int err = 0;
+	int count = 0;
+
+	while (1) {
+		err = bpf_map_get_next_id(id, &next_id);
+		if (err) {
+			if (err == -ENOENT)
+				break;
+			return err;
+		}
+
+		if (list_maps) {
+			int fd = 0;
+			struct bpf_map_info info = {};
+			u32 info_len = sizeof(info);
+
+			fd = bpf_map_get_fd_by_id(next_id);
+			if (fd < 0) {
+				return fd;
+			}
+
+			err = bpf_obj_get_info_by_fd(fd, &info, &info_len);
+			if (err) {
+				close(fd);
+				return err;
+			}
+
+			printf("Map %u, %s\n", info.id, info.name);
+			close(fd);
+		}
+
+		count++;
+		id = next_id;
+	}
+
+	return count;
+}
+
+static struct xsk_umem_info *xsk_configure_umem(void *buffer, u64 size)
+{
+	struct xsk_umem_info *umem;
+
+	umem = calloc(1, sizeof(*umem));
+	if (!umem)
+		exit(EXIT_FAILURE);
+
+	DECLARE_LIBXDP_OPTS(xsk_umem_opts, opts,
+		.size = size,
+	);
+	umem->umem = xsk_umem__create_opts(buffer, &umem->fq, &umem->cq, &opts);
+	if (!umem->umem)
+		exit(errno);
+
+	umem->buffer = buffer;
+	return umem;
+}
+
+static struct xsk_socket_info *xsk_configure_socket(struct xsk_umem_info *umem,
+						    unsigned int qid)
+{
+	struct xsk_socket_info *xsk;
+	struct xsk_ring_cons *rxr;
+
+	xsk = calloc(1, sizeof(*xsk));
+	if (!xsk)
+		exit(EXIT_FAILURE);
+
+	xsk->umem = umem;
+	rxr = &xsk->rx;
+	DECLARE_LIBXDP_OPTS(xsk_socket_opts, opts,
+		.rx = rxr,
+		.rx_size = XSK_RING_CONS__DEFAULT_NUM_DESCS,
+	);
+	xsk->xsk = xsk_socket__create_opts(opt_if, qid, umem->umem, &opts);
+
+	return xsk;
+}
+
+static struct xsk_socket_info *create_socket(u32 qid)
+{
+	struct xsk_umem_info *umem;
+	void *buffs;
+
+	if (posix_memalign(&buffs,
+			   getpagesize(), /* PAGE_SIZE aligned */
+			   NUM_FRAMES * FRAME_SIZE)) {
+		fprintf(stderr, "ERROR: Can't allocate buffer memory \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	umem = xsk_configure_umem(buffs, NUM_FRAMES * FRAME_SIZE);
+	return xsk_configure_socket(umem, qid);
+}
+
+static void delete_socket(u32 qid)
+{
+	struct xsk_umem *umem;
+	void *buff;
+
+	buff = xsks[qid]->umem->buffer;
+	umem = xsks[qid]->umem->umem;
+	xsk_socket__delete(xsks[qid]->xsk);
+	free(buff);
+	(void)xsk_umem__delete(umem);
+}
+
+static void xsk_prog_detach(void)
+{
+	int ifindex = if_nametoindex(opt_if);
+	struct xdp_multiprog *mp = NULL;
+	int err = 0;
+
+	mp = xdp_multiprog__get_from_ifindex(ifindex);
+	if (libxdp_get_error(mp)) {
+		fprintf(stderr, "Failed to get mp, error %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	err = xdp_multiprog__detach(mp);
+	if (err) {
+		fprintf(stderr, "Failed to get mp, error %s\n", strerror(-err));
+		exit(EXIT_FAILURE);
+	}
+
+	xdp_multiprog__close(mp);
+}
+
+static void create_and_tear_down_xsk(void)
+{
+	u32 i;
+
+	for (i = 0; i < MAX_NUM_QUEUES; i++) {
+		xsks[i] = create_socket(i);
+		if (libxdp_get_error(xsks[i]->xsk)) {
+			fprintf(stderr, "Failed to create socket %u: %s\n",
+					i, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	xsk_prog_detach();
+
+	for (i = 0; i < MAX_NUM_QUEUES; i++)
+		delete_socket(i);
+}
+
+static int read_args(int argc, char **argv)
+{
+	if (argc != 2)
+		return -1;
+
+	opt_if = argv[1];
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	int num_maps_before = 0;
+	int num_maps_after = 0;
+
+	if (read_args(argc, argv))
+		return -1;
+
+	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+		fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+			strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	silence_libbpf_logging();
+
+	printf("Maps before:\n");
+	num_maps_before = count_bpf_maps(true);
+	if (num_maps_before < 0) {
+		fprintf(stderr, "Failure on getting maps before, %s\n",
+				strerror(-num_maps_before));
+		exit(EXIT_FAILURE);
+	}
+
+	create_and_tear_down_xsk();
+	kern_sync_rcu();
+
+	printf("Maps after:\n");
+	num_maps_after = count_bpf_maps(true);
+	if (num_maps_after < 0) {
+		fprintf(stderr, "Failure on getting maps after, %s\n",
+				strerror(-num_maps_before));
+		exit(EXIT_FAILURE);
+	}
+
+	if (num_maps_before != num_maps_after) {
+		fprintf(stderr, "Maps leaked, before %d, after %d\n",
+				num_maps_before, num_maps_after);
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Test map leaks PASSED\n");
+
+	return 0;
+}

--- a/lib/libxdp/xsk.c
+++ b/lib/libxdp/xsk.c
@@ -1336,6 +1336,10 @@ static void xsk_release_xdp_prog(struct xsk_socket *xsk)
 	if (value < 0)
 		pr_warn("Error occurred when decrementing xsk XDP prog refcount: %s, please detach program yourself\n",
 			strerror(-value));
+
+	close(ctx->refcnt_map_fd);
+	ctx->refcnt_map_fd = -ENOENT;
+
 	if (value)
 		goto out;
 


### PR DESCRIPTION
refcnt_map_fd leaks in scenario where AF_XDP socket is configured and tore down in loops. Reproduce by creating and closing AF_XDP socket within the same process and observing bpf map xsk_def_.data not to be cleaned.

Sample program is attached. To reproduce, start mini-sample with interface name, e.g.

./mini-sample eth0

Program will create and tear down AF_XDP socket. In separate terminal execute 

bpftool map

and observe that with each initialization of AF_XDP socket within the same process "xsk_def_.data" leaks.

[mini-sample.c](https://github.com/user-attachments/files/27704700/mini-sample.c)
