### PR TITLE
Use parsing helpers in xdp-forward

### DIFF
--- a/headers/xdp/parsing_helpers.h
+++ b/headers/xdp/parsing_helpers.h
@@ -26,6 +26,9 @@
 #include <linux/in.h>
 #include <bpf/bpf_endian.h>
 
+#define IP_MF				0x2000	/* "More Fragments" */
+#define IP_OFFSET			0x1fff	/* "Fragment Offset" */
+
 /* Header cursor to keep track of current parsing position */
 struct hdr_cursor {
 	void *pos;
@@ -132,7 +135,8 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 
 static __always_inline int skip_ip6hdrext(struct hdr_cursor *nh,
 					  void *data_end,
-					  __u8 next_hdr_type)
+					  __u8 next_hdr_type,
+					  __u8 frags_ok)
 {
 	for (int i = 0; i < IPV6_EXT_MAX_CHAIN; ++i) {
 		struct ipv6_opt_hdr *hdr = nh->pos;
@@ -153,6 +157,8 @@ static __always_inline int skip_ip6hdrext(struct hdr_cursor *nh,
 			next_hdr_type = hdr->nexthdr;
 			break;
 		case IPPROTO_FRAGMENT:
+			if (!frags_ok)
+				return -1;
 			nh->pos = (char *)hdr + 8;
 			next_hdr_type = hdr->nexthdr;
 			break;
@@ -165,9 +171,10 @@ static __always_inline int skip_ip6hdrext(struct hdr_cursor *nh,
 	return -1;
 }
 
-static __always_inline int parse_ip6hdr(struct hdr_cursor *nh,
-					void *data_end,
-					struct ipv6hdr **ip6hdr)
+static __always_inline int __parse_ip6hdr(struct hdr_cursor *nh,
+					  void *data_end,
+					  struct ipv6hdr **ip6hdr,
+					  __u8 frags_ok)
 {
 	struct ipv6hdr *ip6h = nh->pos;
 
@@ -181,12 +188,20 @@ static __always_inline int parse_ip6hdr(struct hdr_cursor *nh,
 	nh->pos = ip6h + 1;
 	*ip6hdr = ip6h;
 
-	return skip_ip6hdrext(nh, data_end, ip6h->nexthdr);
+	return skip_ip6hdrext(nh, data_end, ip6h->nexthdr, frags_ok);
 }
 
-static __always_inline int parse_iphdr(struct hdr_cursor *nh,
+static __always_inline int parse_ip6hdr(struct hdr_cursor *nh,
+					void *data_end,
+					struct ipv6hdr **ip6hdr)
+{
+	return __parse_ip6hdr(nh, data_end, ip6hdr, 1);
+}
+
+static __always_inline int __parse_iphdr(struct hdr_cursor *nh,
 				       void *data_end,
-				       struct iphdr **iphdr)
+				       struct iphdr **iphdr,
+				       __u8 frags_ok)
 {
 	struct iphdr *iph = nh->pos;
 	int hdrsize;
@@ -200,10 +215,21 @@ static __always_inline int parse_iphdr(struct hdr_cursor *nh,
 	if (nh->pos + hdrsize > data_end)
 		return -1;
 
+	/* ip fragmented traffic */
+	if (!frags_ok && iph->frag_off & bpf_htons(IP_MF | IP_OFFSET))
+		return -1;
+
 	nh->pos += hdrsize;
 	*iphdr = iph;
 
 	return iph->protocol;
+}
+
+static __always_inline int parse_iphdr(struct hdr_cursor *nh,
+				       void *data_end,
+				       struct iphdr **iphdr)
+{
+	return __parse_iphdr(nh, data_end, iphdr, 1);
 }
 
 static __always_inline int parse_arphdr(struct hdr_cursor *nh,

--- a/headers/xdp/parsing_helpers.h
+++ b/headers/xdp/parsing_helpers.h
@@ -106,7 +106,6 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 		return -1;
 
 	nh->pos = eth + 1;
-	*ethhdr = eth;
 	vlh = nh->pos;
 	h_proto = eth->h_proto;
 
@@ -126,6 +125,8 @@ static __always_inline int parse_ethhdr(struct hdr_cursor *nh, void *data_end,
 	}
 
 	nh->pos = vlh;
+	if (ethhdr)
+		*ethhdr = eth;
 	return h_proto; /* network-byte-order */
 }
 

--- a/xdp-forward/xdp_flowtable.bpf.c
+++ b/xdp-forward/xdp_flowtable.bpf.c
@@ -12,8 +12,6 @@
 
 #define IPV6_FLOWINFO_MASK              bpf_htons(0x0FFFFFFF)
 
-#define IP_MF				0x2000	/* "More Fragments" */
-#define IP_OFFSET			0x1fff	/* "Fragment Offset" */
 #define CSUM_MANGLED_0			((__sum16)0xffff)
 
 #define BIT(x)				(1 << (x))
@@ -589,11 +587,12 @@ static __always_inline int xdp_flowtable_flags(struct xdp_md *ctx,
 					       __u32 fib_flags)
 {
 	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	struct hdr_cursor nh = { .pos = data };
 	struct flow_offload_tuple_rhash *tuplehash;
 	struct bpf_fib_lookup tuple = {
 		.ifindex = ctx->ingress_ifindex,
 	};
-	void *data = (void *)(long)ctx->data;
 	struct bpf_flowtable_opts opts = {};
 	enum flow_offload_tuple_dir dir;
 	struct ethhdr *eth = data;
@@ -601,31 +600,27 @@ static __always_inline int xdp_flowtable_flags(struct xdp_md *ctx,
 	struct flow_ports *ports;
 	unsigned long flags;
 	__u8 xmit_type;
+	int eth_type;
 
-	if (eth + 1 > data_end)
-		return XDP_PASS;
-
-	switch (eth->h_proto) {
+	eth_type = parse_ethhdr(&nh, data_end, NULL);
+	switch (eth_type) {
 	case bpf_htons(ETH_P_IP): {
-		struct iphdr *iph = data + sizeof(*eth);
+		struct iphdr *iph;
+		int ip_type;
 
-		ports = (struct flow_ports *)(iph + 1);
+		ip_type = __parse_iphdr(&nh, data_end, &iph, 0);
+		if (ip_type != IPPROTO_TCP && ip_type != IPPROTO_UDP)
+			return XDP_PASS;
+
+		ports = (struct flow_ports *)(nh.pos);
 		if (ports + 1 > data_end)
-			return XDP_PASS;
-
-		/* ip fragmented traffic */
-		if (iph->frag_off & bpf_htons(IP_MF | IP_OFFSET))
-			return XDP_PASS;
-
-		/* ip options */
-		if (iph->ihl * 4 != sizeof(*iph))
 			return XDP_PASS;
 
 		if (iph->ttl <= 1)
 			return XDP_PASS;
 
 		if (xdp_flowtable_check_tcp_state(ports, data_end,
-						  iph->protocol) < 0)
+						  ip_type) < 0)
 			return XDP_PASS;
 
 		tuple.family		= AF_INET;
@@ -641,9 +636,14 @@ static __always_inline int xdp_flowtable_flags(struct xdp_md *ctx,
 	case bpf_htons(ETH_P_IPV6): {
 		struct in6_addr *src = (struct in6_addr *)tuple.ipv6_src;
 		struct in6_addr *dst = (struct in6_addr *)tuple.ipv6_dst;
-		struct ipv6hdr *ip6h = data + sizeof(*eth);
+		struct ipv6hdr *ip6h;
+		int ip_type;
 
-		ports = (struct flow_ports *)(ip6h + 1);
+		ip_type = __parse_ip6hdr(&nh, data_end, &ip6h, 0);
+		if (ip_type != IPPROTO_TCP && ip_type != IPPROTO_UDP)
+			return XDP_PASS;
+
+		ports = (struct flow_ports *)(nh.pos);
 		if (ports + 1 > data_end)
 			return XDP_PASS;
 

--- a/xdp-forward/xdp_forward.bpf.c
+++ b/xdp-forward/xdp_forward.bpf.c
@@ -33,52 +33,46 @@ static __always_inline int xdp_fwd_flags(struct xdp_md *ctx, __u32 flags)
 {
 	void *data_end = (void *)(long)ctx->data_end;
 	void *data = (void *)(long)ctx->data;
+	struct hdr_cursor nh = { .pos = data };
 	struct bpf_fib_lookup fib_params;
-	struct ethhdr *eth = data;
+	int rc, eth_type, ip_type;
 	struct ipv6hdr *ip6h;
+	struct ethhdr *eth;
 	struct iphdr *iph;
-	__u16 h_proto;
-	__u64 nh_off;
-	int rc;
-
-	nh_off = sizeof(*eth);
-	if (data + nh_off > data_end)
-		return XDP_DROP;
 
 	__builtin_memset(&fib_params, 0, sizeof(fib_params));
 
-	h_proto = eth->h_proto;
-	if (h_proto == bpf_htons(ETH_P_IP)) {
-		iph = data + nh_off;
-
-		if (iph + 1 > data_end)
-			return XDP_DROP;
+	eth_type = parse_ethhdr(&nh, data_end, &eth);
+	if (eth_type == bpf_htons(ETH_P_IP)) {
+		ip_type = parse_iphdr(&nh, data_end, &iph);
+		if (ip_type < 0)
+			return XDP_PASS;
 
 		if (iph->ttl <= 1)
 			return XDP_PASS;
 
 		fib_params.family	= AF_INET;
 		fib_params.tos		= iph->tos;
-		fib_params.l4_protocol	= iph->protocol;
+		fib_params.l4_protocol	= ip_type;
 		fib_params.sport	= 0;
 		fib_params.dport	= 0;
 		fib_params.tot_len	= bpf_ntohs(iph->tot_len);
 		fib_params.ipv4_src	= iph->saddr;
 		fib_params.ipv4_dst	= iph->daddr;
-	} else if (h_proto == bpf_htons(ETH_P_IPV6)) {
+	} else if (eth_type == bpf_htons(ETH_P_IPV6)) {
 		struct in6_addr *src = (struct in6_addr *) fib_params.ipv6_src;
 		struct in6_addr *dst = (struct in6_addr *) fib_params.ipv6_dst;
 
-		ip6h = data + nh_off;
-		if (ip6h + 1 > data_end)
-			return XDP_DROP;
+		ip_type = parse_ip6hdr(&nh, data_end, &ip6h);
+		if (ip_type < 0)
+			return XDP_PASS;
 
 		if (ip6h->hop_limit <= 1)
 			return XDP_PASS;
 
 		fib_params.family	= AF_INET6;
 		fib_params.flowinfo	= *(__be32 *)ip6h & IPV6_FLOWINFO_MASK;
-		fib_params.l4_protocol	= ip6h->nexthdr;
+		fib_params.l4_protocol	= ip_type;
 		fib_params.sport	= 0;
 		fib_params.dport	= 0;
 		fib_params.tot_len	= bpf_ntohs(ip6h->payload_len);
@@ -119,9 +113,9 @@ static __always_inline int xdp_fwd_flags(struct xdp_md *ctx, __u32 flags)
 		if (!bpf_map_lookup_elem(&xdp_tx_ports, &fib_params.ifindex))
 			return XDP_PASS;
 
-		if (h_proto == bpf_htons(ETH_P_IP))
+		if (ip_type == bpf_htons(ETH_P_IP))
 			ip_decrease_ttl(iph);
-		else if (h_proto == bpf_htons(ETH_P_IPV6))
+		else if (ip_type == bpf_htons(ETH_P_IPV6))
 			ip6h->hop_limit--;
 
 		__builtin_memcpy(eth->h_dest, fib_params.dmac, ETH_ALEN);


### PR DESCRIPTION
The BPF programs in xdp-forward was not using the same parsing helpers as other
utilities, leading to inconsistencies in parsing. Switch them over to ensure we
parse packets the same way everywhere.