### PR TITLE
xdp-bench: fix get_port_ipv6_tcp testing nexthdr against IPPROTO_UDP

### DIFF
--- a/xdp-bench/xdp_redirect_cpumap.bpf.c
+++ b/xdp-bench/xdp_redirect_cpumap.bpf.c
@@ -174,7 +174,7 @@ __u16 get_port_ipv6_tcp(struct xdp_md *ctx, __u64 nh_off, bool src)
 
 	if (ip6h + 1 > data_end)
 		return 0;
-	if (!(ip6h->nexthdr == IPPROTO_UDP))
+	if (!(ip6h->nexthdr == IPPROTO_TCP))
 		return 0;
 
 	tcph = (void *)(ip6h + 1);


### PR DESCRIPTION
`get_port_ipv6_tcp()` in
`xdp-bench/xdp_redirect_cpumap.bpf.c` proceeds only when
`ip6h->nexthdr == IPPROTO_UDP`, then casts the bytes after the IPv6
header to a `struct tcphdr` and reads the ports. The constant is
wrong for the TCP variant: a real IPv6/TCP packet has
`nexthdr == IPPROTO_TCP`, so the function always returns 0 for
legitimate TCP traffic.

The function is reached. `cpumap_l4_port()` calls it in the IPv6/TCP
arm of the L4 demux, so v6/TCP port-based cpumap steering never gets
real ports. Every v6/TCP packet hashes to `port % cpu_max` with
`port == 0`, i.e. cpu_idx 0 every time.

Both v6 port helpers (`get_port_ipv6_tcp` and `get_port_ipv6_udp`)
were added together in `c9913f9ffc8b` ("xdp-bench: Add l4-sport and
l4-dport cpumap modes"); they share a near-identical skeleton and
the TCP variant carried the UDP variant's nexthdr constant over
unchanged.

Fix: test against `IPPROTO_TCP`. BPF object builds clean.
