### PR TITLE
libxdp: bound dispatcher map size and program count on read-back

### DIFF
--- a/lib/libxdp/libxdp.c
+++ b/lib/libxdp/libxdp.c
@@ -2329,6 +2329,12 @@ static int check_dispatcher_version(struct xdp_multiprog *mp,
 	{
 		struct xdp_dispatcher_config_v1 *config = (void *)buf;
 
+		if (map_info.value_size < sizeof(*config)) {
+			pr_warn("Dispatcher v1 map size %u < expected %zu\n",
+				map_info.value_size, sizeof(*config));
+			err = -EINVAL;
+			goto out;
+		}
 		for (i = 0; i < MAX_DISPATCHER_ACTIONS; i++) {
 			mp->config.chain_call_actions[i] =
 				config->chain_call_actions[i];
@@ -2341,6 +2347,12 @@ static int check_dispatcher_version(struct xdp_multiprog *mp,
 	{
 		struct xdp_dispatcher_config_v2 *config = (void *)buf;
 
+		if (map_info.value_size < sizeof(*config)) {
+			pr_warn("Dispatcher v2 map size %u < expected %zu\n",
+				map_info.value_size, sizeof(*config));
+			err = -EINVAL;
+			goto out;
+		}
 		for (i = 0; i < MAX_DISPATCHER_ACTIONS; i++) {
 			mp->config.chain_call_actions[i] = config->chain_call_actions[i];
 			mp->config.run_prios[i] = config->run_prios[i];
@@ -2368,6 +2380,14 @@ static int check_dispatcher_version(struct xdp_multiprog *mp,
 		err = -EOPNOTSUPP;
 		goto out;
 	}
+
+	if (mp->config.num_progs_enabled > MAX_DISPATCHER_ACTIONS) {
+		pr_warn("Dispatcher num_progs_enabled %u exceeds max %u\n",
+			mp->config.num_progs_enabled, MAX_DISPATCHER_ACTIONS);
+		err = -EINVAL;
+		goto out;
+	}
+
 	pr_debug("Verified XDP dispatcher version %d <= %d\n",
 		 version, XDP_DISPATCHER_VERSION);
 


### PR DESCRIPTION
`check_dispatcher_version()` in `lib/libxdp/libxdp.c` reads a pinned
dispatcher config map into a buffer sized by the map's `value_size`
(only floored at 2) and casts it to a version-specific struct. Two
read-back paths are unbounded:

1. The V1 and V2 compatibility branches read
   `MAX_DISPATCHER_ACTIONS` array entries out of the buffer
   regardless of its size, so a dispatcher map whose `value_size` is
   smaller than the V1/V2 struct causes an out-of-bounds heap read.
   The current `XDP_DISPATCHER_VERSION` branch already validates
   `value_size` exactly.

2. `mp->config.num_progs_enabled` is a `__u8` set from the map in
   all three version paths and is then used unbounded by
   `xdp_multiprog__link_pinned_progs()` as the loop count over
   arrays that are `MAX_DISPATCHER_ACTIONS` wide, so a value above
   the array width overruns the in-memory `mp->config` arrays.

Guard the V1 and V2 branches with a lower-bound `value_size` check
(`value_size < sizeof(*config)`) and, after the version switch,
reject `num_progs_enabled > MAX_DISPATCHER_ACTIONS`. The post-switch
placement covers V1, V2 and V3 in one check.

The V1/V2 size check is a lower bound rather than the exact match
(`!=`) the current-version branch uses: V1/V2 read a fixed-width
prefix field-by-field and tolerate trailing bytes, whereas the
current branch `memcpy`s the whole struct and so requires an exact
size. `num_progs_enabled` is rejected only when strictly greater
than `MAX_DISPATCHER_ACTIONS`, since the consuming loop indexes
arrays of that width and a value equal to the width is still in
range.

Reaching either site requires a crafted pinned dispatcher map
(`CAP_BPF`), so this is hardening rather than a remotely reachable
bug. `libxdp.o` builds clean `-Werror -Wextra`.
