### PR TITLE
xdp-filter: note --keep-maps does not preserve the policy

### DIFF
--- a/xdp-filter/README.org
+++ b/xdp-filter/README.org
@@ -109,6 +109,13 @@ However, this will also remove the contents of the maps (the filtering rules),
 so this option can be used to keep the maps around so the rules persist until
 =xdp-filter= is loaded again.
 
+Caution: the persisted maps don't record the policy they were created
+under. Reloading =xdp-filter= afterwards under the opposite policy
+(=allow= vs =deny=) reuses the same entries with the new policy's
+semantics, so an allowlist becomes a denylist and vice versa. To
+switch policies safely, unload without =--keep-maps= so the maps are
+cleared, then load fresh under the new policy.
+
 ** -v, --verbose
 Enable debug logging. Specify twice for even more verbosity.
 

--- a/xdp-filter/xdp-filter.8
+++ b/xdp-filter/xdp-filter.8
@@ -1,4 +1,4 @@
-.TH "xdp-filter" "8" "SEPTEMBER  5, 2022" "V1.6.3" "A simple XDP-powered packet filter"
+.TH "xdp-filter" "8" "JUNE  9, 2026" "V1.6.3" "A simple XDP-powered packet filter"
 .SH "NAME"
 xdp-filter \- a simple XDP-powered packet filter
 .SH "SYNOPSIS"
@@ -120,6 +120,14 @@ default, all BPF maps no longer needed by any loaded program are removed.
 However, this will also remove the contents of the maps (the filtering rules),
 so this option can be used to keep the maps around so the rules persist until
 \fIxdp\-filter\fP is loaded again.
+
+.PP
+Caution: the persisted maps don't record the policy they were created
+under. Reloading \fIxdp\-filter\fP afterwards under the opposite policy
+(\fIallow\fP vs \fIdeny\fP) reuses the same entries with the new policy's
+semantics, so an allowlist becomes a denylist and vice versa. To
+switch policies safely, unload without \fI\-\-keep\-maps\fP so the maps are
+cleared, then load fresh under the new policy.
 .SS "-v, --verbose"
 .PP
 Enable debug logging. Specify twice for even more verbosity.


### PR DESCRIPTION
`xdp-filter`'s persisted maps under `--keep-maps` don't record the
policy (`allow` or `deny`) they were created under. Reloading
`xdp-filter` afterwards under the opposite policy reuses the same
entries with the new policy's semantics, so an allowlist is silently
turned into a denylist and vice versa.

Document this in the `-k, --keep-maps` section of the man page and
point users at the unload-fresh path for switching policies safely.
The added paragraph uses "policy" (matching the existing `-p,
--policy` option) rather than "mode", to avoid collision with `-m,
--mode` (native/skb/hw).

Docs-only.
