### PR TITLE
xdp-trafficgen: Reduce accounting cost

### DIFF
--- a/headers/xdp/xdp_sample_common.bpf.h
+++ b/headers/xdp/xdp_sample_common.bpf.h
@@ -263,8 +263,13 @@ int BPF_PROG(tp_xdp_devmap_xmit_multi, const struct net_device *from_dev,
 	if (!IN_SET(to_match, idx_out))
 		return 0;
 
-	bpf_map_update_elem(&devmap_xmit_cnt_multi, &idx, &empty, BPF_NOEXIST);
 	rec = bpf_map_lookup_elem(&devmap_xmit_cnt_multi, &idx);
+	if (!rec) {
+		/* Defer creation of the entry to when lookup fails. */
+		bpf_map_update_elem(&devmap_xmit_cnt_multi, &idx, &empty, BPF_NOEXIST);
+		rec = bpf_map_lookup_elem(&devmap_xmit_cnt_multi, &idx);
+	}
+
 	if (!rec)
 		return 0;
 


### PR DESCRIPTION
When the tracepoint is active for xdp_devmap_xmit, we will constantly hammer bucket spin lock even when the entry already exists. This scales poorly with multiple threads generating traffic. Defer update to create the entry to first lookup failure, so that contention can be avoided.

Before this change, up to 30% of time on CPUs would be spent in the slow path, and after this the contention drops to 0. In a test scenario xmit/s went from 15 million to 20 million with 16 threads.