### PR TITLE
xdp-bench: fix cpumap round-robin iterator overrun on startup race

### DIFF
--- a/xdp-bench/xdp_redirect_cpumap.bpf.c
+++ b/xdp-bench/xdp_redirect_cpumap.bpf.c
@@ -304,7 +304,7 @@ int  cpumap_round_robin(struct xdp_md *ctx)
 	cpu_idx = *cpu_iterator;
 
 	*cpu_iterator += 1;
-	if (*cpu_iterator == *cpu_max)
+	if (*cpu_iterator >= *cpu_max)
 		*cpu_iterator = 0;
 
 	cpu_selected = bpf_map_lookup_elem(&cpus_available, &cpu_idx);


### PR DESCRIPTION
cpumap_round_robin() advances a per-CPU iterator and wraps it back to zero when it reaches the number of available CPUs:

```
	*cpu_iterator += 1;
	if (*cpu_iterator == *cpu_max)
		*cpu_iterator = 0;
```

The XDP program is attached and can start receiving traffic before create_cpu_entry() has populated cpus_count (*cpu_max). During that window *cpu_max is 0, so the iterator is never reset and keeps incrementing past the CPU count. Because the wrap test uses exact equality (==), once the iterator has overshot it never equals *cpu_max again, even after cpus_count is set. The iterator then grows without bound and cpus_available lookups fail, so every packet returns XDP_ABORTED and no traffic is redirected.

This is easy to trigger at high packet rates: the per-CPU iterator on the RX CPU was observed stuck at ~1.85e9 with cpus_count correctly set to 2, and 100% of packets aborting.

Use >= instead of == so the wrap is self-correcting: as soon as cpus_count is populated the iterator resets to zero on the next packet and round-robin selection resumes.