### PR TITLE
xdp-forward: fix TTL decrement comparing the L4 protocol to an ethertype

### DIFF
--- a/xdp-forward/xdp_forward.bpf.c
+++ b/xdp-forward/xdp_forward.bpf.c
@@ -113,9 +113,9 @@ static __always_inline int xdp_fwd_flags(struct xdp_md *ctx, __u32 flags)
 		if (!bpf_map_lookup_elem(&xdp_tx_ports, &fib_params.ifindex))
 			return XDP_PASS;
 
-		if (ip_type == bpf_htons(ETH_P_IP))
+		if (eth_type == bpf_htons(ETH_P_IP))
 			ip_decrease_ttl(iph);
-		else if (ip_type == bpf_htons(ETH_P_IPV6))
+		else if (eth_type == bpf_htons(ETH_P_IPV6))
 			ip6h->hop_limit--;
 
 		__builtin_memcpy(eth->h_dest, fib_params.dmac, ETH_ALEN);


### PR DESCRIPTION
Split out of #584 as requested there. Since c5ebaea the TTL update in xdp-forward compares the L4 protocol returned by `parse_iphdr()`/`parse_ip6hdr()` against ethertype constants: the IPv6 arm can never fire, the IPv4 arm fires only for IPPROTO_EGP (`htons(ETH_P_IP)` is 8 on little-endian), and forwarded packets keep their TTL. The commit message has the details, including why it went unnoticed.

Verified standalone at this exact commit against its parent: same veth topology, pktgen IPv6 with hop limit 32; forwarded frames arrive at the sink with hlim 32 on fb6212b (undecremented) and hlim 31 with this fix.
